### PR TITLE
Rename .gitbook.yml to .gitbook.yaml so GitBook reads the config

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md

--- a/.gitbook.yml
+++ b/.gitbook.yml
@@ -1,4 +1,0 @@
-root: ./docs/
-
-structure:
-  readme: README.md


### PR DESCRIPTION
## Problem

The repository's GitBook config is named `.gitbook.yml`, but GitBook only recognizes the file named **`.gitbook.yaml`**. The `.yml` extension is silently ignored, so the `root: ./docs/` and `structure` settings in the file have never actually been applied — the published site works only because the root directory is set in the GitBook UI's Git Sync settings.

This is a documented GitBook gotcha — see [Content configuration](https://docs.gitbook.com/integrations/git-sync/content-configuration).

### Why it matters
- Any `redirects:` added to the file would be ignored (so renamed/moved pages can't get redirects via the repo).
- `structure.summary` was not set, so `SUMMARY.md` was only picked up by default convention.

## Change
- Rename `.gitbook.yml` → `.gitbook.yaml` (content unchanged otherwise).
- Add the explicit `structure.summary: SUMMARY.md` entry.

Low risk: the site root is already configured in the GitBook UI, so this only makes the in-repo config authoritative as intended.

https://claude.ai/code/session_01ACvBqevdzT735T5KHMNRGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACvBqevdzT735T5KHMNRGQ)_