### PR TITLE
Add Offboarding page to Troubleshooting & FAQ

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -325,6 +325,7 @@
   * [LAPS Issues](troubleshooting/laps-issues/README.md)
     * [LAPS account passwords cannot be retrieved](troubleshooting/laps-issues/laps-account-passwords-cannot-be-retrieved.md)
     * [Requested LAPS Accounts are not being created](troubleshooting/laps-issues/requested-laps-accounts-are-not-being-created.md)
+* [Offboarding](troubleshooting/offboarding.md)
 * [Changelog](https://feedback.realmjoin.com/)
 
 ## Legal

--- a/docs/troubleshooting/offboarding.md
+++ b/docs/troubleshooting/offboarding.md
@@ -1,0 +1,56 @@
+---
+description: >-
+  How to offboard RealmJoin from your tenant, covering both Intune-only and full
+  RealmJoin deployments and what tenant deletion means for your data, portal
+  access, and devices.
+---
+
+# Offboarding
+
+If you decide to stop using RealmJoin, follow the steps below to remove it cleanly from your tenant. The exact steps depend on how RealmJoin is deployed in your environment.
+
+{% hint style="warning" %}
+**Remove managed groups first.** Managed groups are only deleted automatically when a subscribed package is removed regularly from the portal. During tenant deletion we do **not** touch any groups, so any managed groups you no longer need must be deleted in the portal **before** you start offboarding.
+{% endhint %}
+
+## Intune only
+
+If you use RealmJoin for Intune management only:
+
+{% stepper %}
+{% step %}
+### Remove RealmJoin from Enterprise Applications
+
+Delete the RealmJoin application from **Enterprise applications** in your Microsoft Entra tenant.
+{% endstep %}
+
+{% step %}
+### Let us know
+
+[Contact us](../legal/support.md) so we can remove the tenant connection on our side.
+{% endstep %}
+{% endstepper %}
+
+## RealmJoin Agent deployed
+
+If the RealmJoin Agent is deployed to your devices, complete all of the steps above and, in addition:
+
+{% stepper %}
+{% step %}
+### Request the cleanup script
+
+[Contact us](../legal/support.md) for a PowerShell script that removes any remaining traces of RealmJoin from your devices.
+{% endstep %}
+{% endstepper %}
+
+## What tenant deletion means
+
+Once we remove the tenant connection on our side:
+
+* We delete all data we stored for your tenant.
+* The RealmJoin Portal can no longer be accessed.
+* Devices will no longer receive new configurations for the RealmJoin Agent.
+
+{% hint style="info" %}
+Managed groups are **not** removed during tenant deletion. Make sure to delete any groups you no longer need in the portal before offboarding.
+{% endhint %}


### PR DESCRIPTION
## Summary

Adds a new **Offboarding** page under the Troubleshooting & FAQ section, documenting how customers can cleanly remove RealmJoin from their tenant. Addresses the request in c4a8/c4a8-issues-products-realmjoin-internal#274.

The page covers:

- **Intune-only** offboarding — remove RealmJoin from Enterprise Applications and contact us to remove the tenant connection.
- **RealmJoin Agent deployed** — all of the above, plus requesting the PowerShell cleanup script to remove remaining traces from devices.
- **What tenant deletion means** — stored data is deleted, the portal becomes inaccessible, and devices stop receiving new RealmJoin Agent configurations.
- A prominent warning that **managed groups are not deleted during tenant deletion** and must be removed in the portal beforehand.

Per the issue's guidance, the page is kept low-key — added as a plain entry within the existing Troubleshooting & FAQ group in `SUMMARY.md` rather than as a prominent top-level item.

## Changes

- Add `docs/troubleshooting/offboarding.md`
- Add the page to `docs/SUMMARY.md` under **Troubleshooting & FAQ**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoNMoLD5Qr9Zg525L668Je

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoNMoLD5Qr9Zg525L668Je)_