### PR TITLE
Add documentation for Native Choco Runtime feature

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -267,6 +267,7 @@
     * [KeyVault](realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/keyvault.md)
     * [Application Insights](realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/application-insights.md)
   * [Notifications](realmjoin-agent/realmjoin-client/showing-notifications.md)
+  * [Native Choco Runtime](realmjoin-agent/realmjoin-client/native-choco-runtime.md)
   * [AnyDesk Integration](realmjoin-agent/realmjoin-client/anydesk-integration/README.md)
     * [AnyDesk configuration](realmjoin-agent/realmjoin-client/anydesk-integration/customer-tasks.md)
 * [User Interface](realmjoin-agent/client-menu/README.md)

--- a/docs/realmjoin-agent/realmjoin-client/README.md
+++ b/docs/realmjoin-agent/realmjoin-client/README.md
@@ -12,6 +12,7 @@ RealmJoin Agent is an optional component that you can use alongside RealmJoin Po
 * [RealmJoin Application / Configuration Deployment and Lifecycle](../../app-management/packages/package-store/package-store-details.md#realmjoin-deployment)
 * [Local Admin Password Solution (LAPS)](local-admin-password-solution-laps/)
 * [Notifications](showing-notifications.md)
+* [Native Choco Runtime](native-choco-runtime.md)
 * [AnyDesk Integration](anydesk-integration/)
 * Audit tasks (collecting device/client information)
 * Advanced Telemetry

--- a/docs/realmjoin-agent/realmjoin-client/native-choco-runtime.md
+++ b/docs/realmjoin-agent/realmjoin-client/native-choco-runtime.md
@@ -1,0 +1,75 @@
+---
+description: >-
+  The Native Choco Runtime is RealmJoin's own package installation engine that
+  replaces the outdated Chocolatey 0.10.3 binary while staying fully compatible
+  with existing packages.
+---
+
+# Native Choco Runtime
+
+{% hint style="info" %}
+The Native Choco Runtime was introduced with **RealmJoin Agent 4.21.6 (Beta)**. While in beta it is **opt-in**: existing clients keep using the classic Chocolatey engine until you explicitly enable the native runtime.
+{% endhint %}
+
+## What it is
+
+When the RealmJoin Agent installs software packages outside of Intune (see [package installation](deploy-apps.md#package-installation)), it has traditionally relied on [Chocolatey](https://chocolatey.org/) as the underlying package engine. RealmJoin shipped a pinned, heavily patched build of the open-source Chocolatey CLI — version **0.10.3** — bundled as `choco.exe` under `C:\ProgramData\chocolatey\`.
+
+The **Native Choco Runtime** replaces that bundled Chocolatey binary with RealmJoin's **own, purpose-built implementation**. It *shims* Chocolatey: it understands the same package format and behaves the same way from a package author's and administrator's point of view, but it no longer depends on the ageing Chocolatey 0.10.3 codebase.
+
+In other words, packages you already use keep working unchanged — only the engine underneath them changes.
+
+## Why we built it
+
+The bundled Chocolatey 0.10.3 has served RealmJoin well for many years, but it carries some long-standing drawbacks:
+
+* **It is outdated.** 0.10.3 is many major versions behind current Chocolatey and no longer receives fixes. Moving to a newer upstream Chocolatey release would introduce breaking changes and behavioural differences that are hard to control across a fleet.
+* **External dependency.** Relying on a third-party binary and its own configuration (`chocolatey.config`, the `lib`/`lib-bad` folders, its logging, etc.) limits how tightly RealmJoin can integrate installation, logging, and error handling.
+* **Maintainability & security.** Owning the runtime lets us fix issues directly, tighten security, and evolve behaviour without waiting on — or diverging from — an upstream project.
+
+By implementing the runtime natively, RealmJoin gains full control over the install pipeline while keeping the familiar Chocolatey-compatible package experience.
+
+## Compatibility
+
+The Native Choco Runtime is designed as a **drop-in replacement**:
+
+* Existing RealmJoin packages (including everything from the [Package Store](../../app-management/packages/package-store/)) install and uninstall the same way.
+* Package arguments / params configured in the RealmJoin Portal continue to work.
+* The [RealmJoin Core Choco Extension](../recommended-packages.md#realmjoin-core-choco-extension) helper cmdlets used inside package scripts remain available.
+* Log files are still written to the usual locations used for [troubleshooting package installations](../../troubleshooting/package-installation-issues/).
+
+{% hint style="warning" %}
+As this runtime is in beta, we recommend validating your most important packages on a pilot ring before rolling it out tenant-wide. Please report any behavioural differences to RealmJoin support so we can address them before general availability.
+{% endhint %}
+
+## How to use it
+
+The runtime is selected through a RealmJoin **setting**, so you can control it centrally instead of touching individual clients. RealmJoin settings cascade, which means you can set a **tenant-wide default** and, where needed, **override it for specific groups** (and the objects within them).
+
+{% stepper %}
+{% step %}
+### Enable it for a pilot group first
+
+Open the settings of a RealmJoin **group** that contains a small set of pilot devices and enable the Native Choco Runtime there. Because group settings take precedence over the tenant-wide default, only those devices switch to the new engine.
+{% endstep %}
+
+{% step %}
+### Validate your packages
+
+Let the pilot devices run their normal package assignments and upgrades. Confirm that installations succeed and check the logs if anything looks off (see [Package Installation Issues](../../troubleshooting/package-installation-issues/)).
+{% endstep %}
+
+{% step %}
+### Roll it out tenant-wide
+
+Once you are confident, enable the Native Choco Runtime as the **tenant-wide default** so that all clients use it. Individual groups can still opt out if you need to keep them on the classic engine temporarily.
+{% endstep %}
+{% endstepper %}
+
+{% hint style="info" %}
+Configuration follows the same tenant-setting / group-override model as the other agent settings described under [General settings](../../realmjoin-settings/general.md) (for example the **Client Configuration** and **LAPS Configuration** tenant settings).
+{% endhint %}
+
+## What is the default
+
+During the 4.21.6 Beta the Native Choco Runtime is **disabled by default**. Clients continue to use the classic, bundled Chocolatey 0.10.3 engine until an administrator enables the native runtime — either tenant-wide or for a specific group. This lets you adopt the new runtime at your own pace and roll it back just as easily while the feature is in beta.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Native Choco Runtime, a new package installation engine introduced in RealmJoin Agent 4.21.6 (Beta) that replaces the outdated Chocolatey 0.10.3 binary while maintaining full compatibility with existing packages.

## Changes Made
- **New documentation page**: Created `native-choco-runtime.md` with detailed information about:
  - What the Native Choco Runtime is and how it differs from the classic Chocolatey engine
  - Rationale for building a native implementation (outdated dependency, maintainability, security)
  - Compatibility guarantees and drop-in replacement capabilities
  - Step-by-step rollout guidance (pilot group → validation → tenant-wide deployment)
  - Default behavior during beta (opt-in, disabled by default)

- **Updated navigation**: Added the new documentation page to the sidebar in `SUMMARY.md` under the RealmJoin Client section
- **Updated index**: Added reference to the new Native Choco Runtime page in the RealmJoin Client README

## Notable Details
- Documentation emphasizes that this is a beta feature with opt-in behavior
- Includes clear guidance on piloting the feature before tenant-wide rollout
- Explains the relationship to existing RealmJoin settings and group-level overrides
- Provides reassurance about package compatibility and logging locations for troubleshooting

https://claude.ai/code/session_01VDJtHVdFkLZ9BNmhMLbPxD