### PR TITLE
docs: add Architecture Overview page under Deployment

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
   * [Limiting the Scope of RealmJoin Portal](realmjoin-deployment/infrastructure/limiting-the-scope-of-realmjoin-portal.md)
   * [Multi User Devices](realmjoin-deployment/infrastructure/multi-user-devices.md)
   * [AVD Templates](realmjoin-deployment/infrastructure/avd-templates.md)
+* [Architecture Overview](realmjoin-deployment/architecture-overview.md)
 
 ## User, Group & Device Management <a href="#ugd-management" id="ugd-management"></a>
 

--- a/docs/realmjoin-deployment/architecture-overview.md
+++ b/docs/realmjoin-deployment/architecture-overview.md
@@ -1,0 +1,136 @@
+---
+description: >-
+  A high-level overview of the RealmJoin architecture: the cloud backend, how
+  managed devices and administrators connect, and which resources RealmJoin uses
+  in your own Microsoft tenant.
+---
+
+# Architecture Overview
+
+RealmJoin is a cloud-native, multi-tenant SaaS and the **Application Lifecycle and Management companion to Microsoft Intune**. It manages application deployment, user/group/device management and process automation across your Entra ID tenant — **with no on-premise servers or local infrastructure**. All backend services are operated by glueckkanja in **Microsoft Azure, hosted in Europe**.
+
+RealmJoin covers three areas:
+
+* **Application Management** – packaging, deployment, a self-service catalog and software reporting.
+* **User, Group and Device Management** – a single, unified view that combines data from Intune, Entra ID, Microsoft Defender, Windows Autopilot and sign-in logs.
+* **Process Automation** – runbooks that run in *your own* Azure Automation account.
+
+## The big picture
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false, "nodeSpacing": 55, "rankSpacing": 90}} }%%
+flowchart LR
+    Admin["Administrators"]
+    Integr["Your integrations"]
+    Device["Managed devices<br/>(RealmJoin Agent)"]
+
+    subgraph RJ["RealmJoin Backend - Azure (Europe)"]
+        direction TB
+        Portal["RealmJoin Portal"]
+        CustApi["Customer-API"]
+        ClientApi["Client-API"]
+        FD{{"Azure Front Door"}}
+        CDN["CDN and Package Server"]
+        Core[("Backend services<br/>and databases")]
+    end
+
+    subgraph Tenant["Your Microsoft tenant"]
+        direction TB
+        Graph["Entra ID / Intune / Defender<br/>(via Microsoft Graph)"]
+        subgraph AzureRes["Your Azure resources"]
+            direction TB
+            KV["Key Vault<br/>(LAPS passwords)"]
+            Autom["Azure Automation<br/>(Runbooks)"]
+            LA["Log Analytics<br/>(Logs)"]
+        end
+    end
+
+    Admin --> Portal
+    Integr --> CustApi
+    Device --> ClientApi
+    Device --> FD
+    FD --> CDN
+
+    Portal --> Core
+    ClientApi --> Core
+    CustApi --> Core
+
+    Core -->|least-privilege access| Graph
+    Core --> KV
+    Core --> Autom
+    Core --> LA
+```
+
+RealmJoin connects to your tenant through **least-privilege Entra ID applications** that you consent to during onboarding. Every action the backend performs is filtered through RealmJoin's **internal role-based access control (RBAC)** model, which evaluates Entra group and role membership.
+
+## Backend components
+
+The backend is a set of independently deployed services running in Microsoft Azure:
+
+| Component | Purpose | Who connects to it |
+| --- | --- | --- |
+| **RealmJoin Portal** | The web interface administrators use to manage applications, devices, users, groups and automation. | Administrators, via Entra ID sign-in (OAuth 2.0 / OpenID Connect). |
+| **Client-API** | The endpoint the optional RealmJoin Agent on each device talks to. | Managed devices, authenticated by device identity (Entra token + device certificate). |
+| **Customer-API** | A programmatic API for your own integrations and automation. | Your systems and tools, using a per-customer API key. |
+| **CDN and Package Server** | Delivers application packages and content to devices. | Managed devices. |
+
+Behind these, RealmJoin runs background processing services and stores data in managed Azure databases and storage. Internal-facing services (such as billing and background jobs) are not reachable from the internet.
+
+## The RealmJoin Agent
+
+The RealmJoin Agent is an **optional** Windows component. When installed, it:
+
+* reports device state to the Client-API on a regular schedule,
+* retrieves a **signed** device configuration (software and policy assignments),
+* runs a local **security assessment** (encryption, patch level, firewall, antivirus) before applying mandatory apps,
+* delivers applications efficiently using an enhanced Chocolatey engine plus **BranchCache** peer-to-peer distribution,
+* supports **LAPS** (local admin password) — passwords are generated on the device and stored in **your own Azure Key Vault**.
+
+```mermaid
+sequenceDiagram
+    participant Device as RealmJoin Agent
+    participant API as Client-API
+    participant CDN as RealmJoin CDN
+
+    Device->>API: Report state & request configuration
+    API-->>Device: Signed configuration (apps & policies)
+    Device->>Device: Security assessment
+    Device->>CDN: Download assigned packages
+    Note over Device: Peer-to-peer package sharing via BranchCache
+```
+
+For details on package delivery and BranchCache, see [Infrastructure Considerations](infrastructure/README.md).
+
+## Process automation (runbooks)
+
+Runbooks run in **your own Azure Automation account** — not in RealmJoin's backend. RealmJoin keeps your runbook library in sync with a curated, open GitHub repository and manages and monitors job execution from the Portal. The runbooks act through the Automation account's **managed identity**, so the permissions they use stay entirely within your control.
+
+See [Connecting Azure Automation](../automation/connecting-azure-automation/README.md) and [Runbooks](../automation/runbooks/README.md) for more.
+
+## Application delivery
+
+Packages are produced by RealmJoin's packaging pipeline and delivered to devices through the RealmJoin **CDN** and **Package Server**, with geo-replicated storage and BranchCache for efficient in-network distribution. Applications can be delivered either through **RealmJoin Deployment** (via the Agent) or as **Intune Deployment** (an intunewin package pushed to your tenant).
+
+## Resources in your own environment
+
+Several capabilities use resources in **your own Microsoft tenant and Azure subscription**, so sensitive data stays under your control:
+
+* **Azure Key Vault** – stores the LAPS local-admin passwords generated on your devices.
+* **Azure Automation** – runs your runbooks under a managed identity you control.
+* **Log Analytics** – stores audit logs and archived runbook logs.
+
+RealmJoin accesses these — and Entra ID, Intune and Defender via Microsoft Graph — using only the least-privilege permissions you grant during onboarding. See [Portal Required Permissions](required-permissions.md) for the full list.
+
+## Security, hosting and data residency
+
+* **Hosting:** All backend services run in **Microsoft Azure**, primarily in the **West Europe** region with backup in **North Europe**. **Customer data does not leave Europe.**
+* **Delivery:** The Portal and APIs are reached directly over HTTPS. Application packages and content are delivered through the RealmJoin **CDN**, fronted by **Azure Front Door** for globally load-balanced distribution.
+* **Encryption in transit:** All connections use HTTPS/TLS.
+* **Identity:** Administrator access uses Entra ID (OAuth 2.0 / OpenID Connect); devices authenticate with their Entra device identity and a device certificate; programmatic APIs use per-customer keys.
+* **Tenant isolation:** Each customer's data is separated, and all backend code paths operate within a per-tenant context.
+* **Least privilege:** RealmJoin's Entra applications request only the permissions needed for the features you enable, and all actions are governed by RealmJoin's internal RBAC model.
+* **Resilience:** Redundant infrastructure with automated failover and point-in-time database recovery; infrastructure is fully defined as code (Terraform).
+
+{% hint style="info" %}
+Externally reachable endpoints are the **Portal, Client-API, Customer-API, CDN and Package Server**. For the full list of hosts to allow in your firewall, see [Infrastructure Considerations](infrastructure/README.md). For more detail on data handling and tenant separation, see [Security & Privacy](../security-and-privacy/README.md).
+{% endhint %}


### PR DESCRIPTION
## Summary

Adds a new customer-facing **Architecture Overview** page to the documentation, placed in the **Deployment** section directly below *Infrastructure Considerations*.

The docs previously had no consolidated architecture page — the backend topology was only implied across *Infrastructure Considerations*, *Security & Privacy* and *Required Permissions*. This page fills that gap.

## What the page covers

- **System landscape** – the RealmJoin cloud backend (Portal, Client-API, Customer-API, CDN/Package Server) and how administrators, managed devices and integrations connect to it.
- **Backend components** – a short table of each externally reachable service and its intended caller.
- **The RealmJoin Agent** – the device configuration/security-assessment/package-delivery flow.
- **Process automation** – runbooks running in the customer's own Azure Automation account.
- **Resources in your own environment** – Key Vault (LAPS), Azure Automation (runbooks) and Log Analytics (logs) in the customer tenant.
- **Security, hosting & data residency** – Azure/Europe hosting, Azure Front Door in front of the CDN, TLS, tenant isolation, least-privilege, resilience.
- Two **Mermaid** diagrams (system landscape + agent flow) and cross-links to existing pages.

## Content sourcing & review

Content was derived from the `realmjoin-complete` codebase and existing docs, then reviewed with the team. Factual points confirmed during review:
- Region model (West Europe primary / North Europe backup, data stays in Europe).
- **Azure Front Door fronts only the CDN**; the Portal and APIs are addressed directly.
- The customer-tenant Azure resources (Key Vault / Automation / Log Analytics) are shown explicitly.

Intentionally kept at a customer-facing altitude — internal implementation detail (individual databases, background job names, resource-group naming, etc.) is deliberately omitted.

## Notes for reviewers

- Please verify the two Mermaid diagrams render correctly in the GitBook preview (they use `htmlLabels: false` to avoid GitBook's label-clipping behavior).
- Navigation: added one entry to `SUMMARY.md` after the *Infrastructure Considerations* block. If you'd prefer it nested *under* Infrastructure Considerations instead of as a sibling, that's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XaR1iC54Pf35j32RUmiMr

---
_Generated by [Claude Code](https://claude.ai/code/session_018XaR1iC54Pf35j32RUmiMr)_