### PR TITLE
Docs updates for Portal v2026.29 (packaging Custom rename, recovery-key rotation, SelfLAPS per-platform)

### DIFF
--- a/docs/app-management/packages/packaging-requests/README.md
+++ b/docs/app-management/packages/packaging-requests/README.md
@@ -16,17 +16,17 @@ macOS packages are currently in preview as we continue refining the macOS packag
 
 We appreciate your patience as we work toward delivering the same level of excellence for macOS that our Windows 11 users currently enjoy.
 
-### Private vs Generic Packaging
+### Custom vs Generic Packaging
 
 #### Generic Packages in RealmJoin
 
 We aim to create packages as **generic** as possible. This allows all settings to be configured via the RealmJoin portal post-app subscription. Our **generic** packages feature unmodified installers provided by vendors, without any customer-specific alterations. These packages are accessible to all customers in the RealmJoin store.
 
-#### Private Packages in RealmJoin
+#### Custom Packages in RealmJoin
 
 **Custom** packages are exclusively available for customers in their **custom** section of the RealmJoin **Package Store**. The **custom** namespaces are used for modified installers, including those customized by the vendor for the customer, such as SAP, or for customer-developed apps and similar cases.
 
-We invite customers to share their evaluation on whether an application can be packaged as _generic_ or requires a _custom_ package, however, the final decision is made by the RealmJoin Packaging Factory. Note that _private_ packages incur additional costs.
+We invite customers to share their evaluation on whether an application can be packaged as _generic_ or requires a _custom_ package, however, the final decision is made by the RealmJoin Packaging Factory. Note that _custom_ packages incur additional costs.
 
 ## Request Types
 
@@ -38,10 +38,15 @@ If an application is not available in the RealmJoin Store, it can be requested f
 
 * **Application binaries**, which must always be uploaded for regular packaging requests (a download URL may be added for reference but is **not** sufficient).
 * **Documentation** describing all required configuration switches as command‑line parameters, registry keys, configuration files, or similar (screenshots are not accepted; PACKaaS does not include Scripting‑as‑a‑Service). Silent/unattended installation commands are always required.
-* **Packaging type selection**, specifying whether the application should be created as a _generic_ package (when no customer‑specific data is included) or as a _private/custom_ package (additional fees may apply). The Packaging Factory may change a request from generic to private if justified; for example, when customer‑specific details are identified during processing. Customers will be informed of such changes before the request is completed.
+* **Packaging type selection**, specifying whether the application should be created as a _generic_ package (when no customer‑specific data is included) or as a _custom_ package (additional fees may apply). The Packaging Factory may change a request from generic to custom if justified; for example, when customer‑specific details are identified during processing. Customers will be informed of such changes before the request is completed.
 * **Contact email address**, which may differ from the currently authenticated user’s email.
 * **Installation parameters**, which may be entered directly in the request instead of embedding them in the ZIP file.
+* **Optional description**, a free‑text field for any additional context you want to pass to the Packaging Factory.
 * **Use of “skip upload”**, which is allowed only when updating or adding parameters to an existing package—binaries must still be provided for all standard packaging requests.
+
+{% hint style="info" %}
+When you start a new package request, the form now highlights existing packages that match your input, helping you spot software that is already available in the RealmJoin Store and avoid duplicate requests.
+{% endhint %}
 
 <figure><img src="../../../.gitbook/assets/26-02-09-10_06_07_msedge.png" alt=""><figcaption><p>RealmJoin packaging request form for new requests. </p></figcaption></figure>
 

--- a/docs/realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/README.md
+++ b/docs/realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/README.md
@@ -214,6 +214,10 @@ The value can also be pure boolean `true`/`false`. This may be used as a wildcar
 In the past it was recommended to set this setting to `true`. However, as we continue to expand RealmJoin, new account types will be added. It is therefore strongly recommended to migrate all `true` values to the more explicit object notation
 {% endhint %}
 
+{% hint style="info" %}
+Starting with **Portal v2026.29**, SelfLAPS can be scoped **per platform**, so you can grant self-service access to Windows and macOS devices independently.
+{% endhint %}
+
 A sample configuration may look like this:
 
 | Group              |                                                           | Comment                                                                                                                                   |

--- a/docs/ugd-management/user-list/device-details.md
+++ b/docs/ugd-management/user-list/device-details.md
@@ -76,6 +76,16 @@ The Support Account will automatically be removed after 12 hours.
 
 See the [LAPS documentation](../../realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/) for more details.
 
+### Recovery Keys
+
+For encrypted devices, RealmJoin Portal can work with the disk-encryption recovery key — **BitLocker** on Windows and **FileVault** on macOS.
+
+Starting with **Portal v2026.29**, you can **rotate** a device's recovery key directly from the RealmJoin Portal. Rotating replaces the existing recovery key with a new one, which takes effect after the device next syncs.
+
+{% hint style="info" %}
+Recovery keys can also be retrieved via the [Show BitLocker Recovery Key](../../automation/runbooks/runbook-references/device/security/show-bitlocker-recovery-key.md) and [Show FileVault Recovery Key](../../automation/runbooks/runbook-references/device/security/show-filevault-recovery-key.md) runbooks.
+{% endhint %}
+
 ## Warranty
 
 Use the **Warranty** tab to display information like remaining vendor warranty time for **supported vendors/devices.**


### PR DESCRIPTION
## Summary

Documents the customer-facing changes from the **Portal v2026.29** changelog. Pure technical fixes and the still-in-beta **Agent App Catalog** (deferred until the upcoming stable release) are intentionally left out.

The **Shadow IT export** from the same changelog was already documented in #26.

## Changes

### 1. Packaging requests: "Private" → "Custom" (complete)
`app-management/packages/packaging-requests/README.md`
- Renamed the "Private" packaging request type to **Custom** consistently (headings + body; previously the page mixed both terms).
- Added the new optional **Description** field to the New Packages request requirements.
- Added a note that the request form now highlights existing packages to help avoid duplicate requests.

### 2. Recovery-key rotation (general note — needs refinement)
`ugd-management/user-list/device-details.md`
- New **Recovery Keys** section: recovery keys (BitLocker/FileVault) can now be rotated directly from the Portal.

### 3. SelfLAPS per-platform scoping (general note — needs refinement)
`realmjoin-agent/.../local-admin-password-solution-laps/README.md`
- Note that SelfLAPS can now be scoped per platform (Windows/macOS).

## ⚠️ Needs a reviewer with Portal access to refine

For items 2 and 3 the changelog was too vague to write exact detail without guessing, so these are deliberately general (no invented config syntax or UI paths):

- **Recovery-key rotation** — confirm the exact Portal location (device details action vs. security area) and ideally add a screenshot. Confirm whether keys are also *shown* on the device page (not just via runbooks).
- **SelfLAPS per-platform** — confirm the exact mechanism: is it new platform keys inside the `Allow.SelfLAPS` object (if so, the JSON shape), or a separate Portal UI setting? I can add the precise syntax/example once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDJtHVdFkLZ9BNmhMLbPxD)_