### PR TITLE
Document native App Catalog tray/Start Menu access

### DIFF
--- a/docs/realmjoin-agent/client-menu/self-service-portal.md
+++ b/docs/realmjoin-agent/client-menu/self-service-portal.md
@@ -109,7 +109,15 @@ To automatically allow RealmJoin portal triggering RJ agent from Microsoft Edge 
 
 #### One-Click Access: Self-Service Portal from the Tray
 
-Using the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#weblinks-for-realmjoin-tray) feature, you can add a tray entry that opens the device-specific Self-Service Portal in Microsoft Edge's app mode (a clean, chromeless window). The configuration dynamically resolves the Entra Device ID at launch, so it works across all Entra-joined devices without per-device customization.&#x20;
+Starting with RealmJoin agent 4.21.15, the App Catalog can be opened directly from the tray menu and, optionally, from the Windows Start Menu, without any manual link configuration.
+
+* Enable the [`AppCatalog.Enabled`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) setting to add an **App Catalog** entry to the RealmJoin tray menu, opening the device's App Catalog page in Microsoft Edge's app mode (a clean, chromeless window).
+* Additionally enable `AppCatalog.CreateStartMenuShortcut` to also create a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.
+
+Both entries dynamically resolve the current device and signed-in user at launch, so they work across all Entra-joined devices without per-device customization.
+
+{% hint style="info" %}
+For agent versions prior to 4.21.15, or as an alternative to the native settings above, you can use the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#weblinks-for-realmjoin-tray) feature to add a similar tray entry manually:
 
 ```json
 [
@@ -121,6 +129,7 @@ Using the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-se
   }
 ]
 ```
+{% endhint %}
 
 ***
 

--- a/docs/realmjoin-agent/client-menu/self-service-portal.md
+++ b/docs/realmjoin-agent/client-menu/self-service-portal.md
@@ -116,21 +116,6 @@ Starting with RealmJoin agent 4.21.15, the App Catalog can be opened directly fr
 
 Both entries dynamically resolve the current device and signed-in user at launch, so they work across all Entra-joined devices without per-device customization.
 
-{% hint style="info" %}
-You can use the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#weblinks-for-realmjoin-tray) feature to add a similar tray entry manually:
-
-```json
-[
-  {
-    "Name": "My App Catalog",
-    "Target": "conhost",
-    "Args": "--headless powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command $id=(dsregcmd /status|Select-String '^\\s*DeviceId\\s*:'|Select-Object -First 1).ToString().Split(':')[1].Trim();Start-Process msedge -ArgumentList ('--app=https://portal.realmjoin.com/devices/'+$id+'/user-app-catalog')",
-    "Platform": "any"
-  }
-]
-```
-{% endhint %}
-
 ***
 
 ## Self Service Forms

--- a/docs/realmjoin-agent/client-menu/self-service-portal.md
+++ b/docs/realmjoin-agent/client-menu/self-service-portal.md
@@ -117,7 +117,7 @@ Starting with RealmJoin agent 4.21.15, the App Catalog can be opened directly fr
 Both entries dynamically resolve the current device and signed-in user at launch, so they work across all Entra-joined devices without per-device customization.
 
 {% hint style="info" %}
-For agent versions prior to 4.21.15, or as an alternative to the native settings above, you can use the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#weblinks-for-realmjoin-tray) feature to add a similar tray entry manually:
+You can use the [Weblinks](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#weblinks-for-realmjoin-tray) feature to add a similar tray entry manually:
 
 ```json
 [

--- a/docs/realmjoin-agent/client-menu/self-service-portal.md
+++ b/docs/realmjoin-agent/client-menu/self-service-portal.md
@@ -109,7 +109,7 @@ To automatically allow RealmJoin portal triggering RJ agent from Microsoft Edge 
 
 #### One-Click Access: Self-Service Portal from the Tray
 
-Starting with RealmJoin agent 4.21.15, the App Catalog can be opened directly from the tray menu and, optionally, from the Windows Start Menu, without any manual link configuration.
+The App Catalog can be opened directly from the tray menu and, optionally, from the Windows Start Menu, without any manual link configuration.
 
 * Enable the [`AppCatalog.Enabled`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) setting to add an **App Catalog** entry to the RealmJoin tray menu, opening the device's App Catalog page in Microsoft Edge's app mode (a clean, chromeless window).
 * Additionally enable `AppCatalog.CreateStartMenuShortcut` to also create a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.

--- a/docs/ugd-management/user-and-group-settings/additional-settings.md
+++ b/docs/ugd-management/user-and-group-settings/additional-settings.md
@@ -309,7 +309,7 @@ LocalAdminManagement.SupportAccount
 
 ### AppCatalog Feature
 
-This setting controls native, one-click access to the [App Catalog](../../realmjoin-agent/client-menu/self-service-portal.md#app-catalog-tab) from the RealmJoin tray menu and Windows Start Menu, available from RealmJoin agent 4.21.15 onwards.
+This setting controls native, one-click access to the [App Catalog](../../realmjoin-agent/client-menu/self-service-portal.md#app-catalog-tab) from the RealmJoin tray menu and Windows Start Menu.
 
 **Key**\
 AppCatalog

--- a/docs/ugd-management/user-and-group-settings/additional-settings.md
+++ b/docs/ugd-management/user-and-group-settings/additional-settings.md
@@ -307,6 +307,29 @@ LocalAdminManagement.SupportAccount
 }
 ```
 
+### AppCatalog Feature
+
+This setting controls native, one-click access to the [App Catalog](../../realmjoin-agent/client-menu/self-service-portal.md#app-catalog-tab) from the RealmJoin tray menu and Windows Start Menu, available from RealmJoin agent 4.21.15 onwards.
+
+**Key**\
+AppCatalog
+
+**Value**
+
+```json
+{
+  "Enabled": true | false,
+  "HidePackages": true | false,
+  "CreateStartMenuShortcut": true | false,
+  "Url": "https://portal.realmjoin.com"
+}
+```
+
+* **Enabled:** Adds an **App Catalog** entry to the RealmJoin tray menu that opens the device's App Catalog page in Microsoft Edge app mode.
+* **HidePackages:** Hides the individual software packages from the classic tray "Install"/"Update" submenu, useful once users are directed to the App Catalog instead.
+* **CreateStartMenuShortcut:** Requires `Enabled: true`. Creates a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.
+* **Url:** Optional override for the RealmJoin portal base URL. Defaults to the standard RealmJoin portal.
+
 ### Weblinks for RealmJoin Tray
 
 The following setting generates a weblink in the tray.

--- a/docs/ugd-management/user-and-group-settings/additional-settings.md
+++ b/docs/ugd-management/user-and-group-settings/additional-settings.md
@@ -320,15 +320,13 @@ AppCatalog
 {
   "Enabled": true | false,
   "HidePackages": true | false,
-  "CreateStartMenuShortcut": true | false,
-  "Url": "https://portal.realmjoin.com"
+  "CreateStartMenuShortcut": true | false
 }
 ```
 
 * **Enabled:** Adds an **App Catalog** entry to the RealmJoin tray menu that opens the device's App Catalog page in Microsoft Edge app mode.
 * **HidePackages:** Hides the individual software packages from the classic tray "Install"/"Update" submenu, useful once users are directed to the App Catalog instead.
 * **CreateStartMenuShortcut:** Requires `Enabled: true`. Creates a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.
-* **Url:** Optional override for the RealmJoin portal base URL. Defaults to the standard RealmJoin portal.
 
 ### Weblinks for RealmJoin Tray
 


### PR DESCRIPTION
## Summary
- Update the "One-Click Access" section on the [Self-Service Portal](https://docs.realmjoin.com/realmjoin-agent/client-menu/self-service-portal) page to describe the native `AppCatalog.Enabled` (tray menu entry) and `AppCatalog.CreateStartMenuShortcut` (Start Menu shortcut) settings, available from RealmJoin agent 4.21.15 onwards. The previous Weblinks-based workaround is kept as an alternative for older agents.
- Add an "AppCatalog Feature" entry to [Available RealmJoin Policies](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings) documenting the `AppCatalog` key (`Enabled`, `HidePackages`, `CreateStartMenuShortcut`, `Url`).

Settings were cross-checked against the `AppCatalog` config in [realmjoin-windows](https://github.com/realmjoin/realmjoin-windows) (`ConfigAppCatalog.cs`, `AppCatalogShortcutSection.cs`, `RealmJoinContext.cs`) to confirm key names, defaults, and behavior.

Closes c4a8/c4a8-issues-products-realmjoin-internal#278

## Test plan
- [ ] Preview rendering in GitBook (hint block, list formatting, anchors)
- [ ] Verify `#appcatalog-feature` and `#weblinks-for-realmjoin-tray` anchor links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)