### PR TITLE
Fix broken Application Management links (#279)

### DIFF
--- a/docs/introduction/navigation.md
+++ b/docs/introduction/navigation.md
@@ -37,7 +37,7 @@ This will give you information and statistics about your Azure tenant, recent ap
 
 "Devices" includes all Entra ID joined clients as well as devices registered in Entra ID, like mobile phones.
 
-## [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+## [Application Management](../app-management/packages/README.md)
 
 ### ![](../.gitbook/assets/packages.png) [Packages](../app-management/packages/package-management.md)
 

--- a/docs/realmjoin-settings/permission/pre-defined-roles.md
+++ b/docs/realmjoin-settings/permission/pre-defined-roles.md
@@ -22,7 +22,7 @@ Simply click on "\[x] groups" and add or remove the desired Entra groups.
 This will grant **full administrative and configuration control** over RealmJoin Portal. This includes e.g.:
 
 * Access to all features of [User, Group and Device Management](../../ugd-management/user-group-device-management.md) and [Process Automation](../../automation/runbooks/)
-* Access to all features of [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Access to all features of [Application Management](../../app-management/packages/README.md)
 * Full access to [Settings](../settings.md) including:
   * Modifying permissions / delegations
   * Onboarding/modifying Runbook integration
@@ -36,7 +36,7 @@ This will grant **full administrative and configuration control** over RealmJoin
 This will grant read-only access to all areas of RealmJoin Portal.
 
 * Read-only access to all areas of [User, Group and Device Management](../../ugd-management/user-group-device-management.md)
-* Read-only access to all features of [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Read-only access to all features of [Application Management](../../app-management/packages/README.md)
 * Reading Runbook Job logs
 
 This permission does not include:
@@ -108,7 +108,7 @@ This will grant:
 
 * Read-only access to [User and Group Management](../../ugd-management/user-group-device-management.md)
   * Full access on application management groups
-* Access to all features of [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Access to all features of [Application Management](../../app-management/packages/README.md)
 
 This permission does not include:
 
@@ -124,7 +124,7 @@ This allows a user to file a request to RealmJoin for a new software package to 
 This permission does not include:
 
 * Access to [User, Group and Device Management](../../ugd-management/user-group-device-management.md)
-* Access to [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Access to [Application Management](../../app-management/packages/README.md)
 * Starting Runbooks or reading Runbook Job logs
 * Access to [Settings](../settings.md)
 
@@ -135,7 +135,7 @@ This allows a user to automatically create a software package from uploaded sour
 This permission does not include:
 
 * Access to [User, Group and Device Management](../../ugd-management/user-group-device-management.md)
-* Access to [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Access to [Application Management](../../app-management/packages/README.md)
 * Starting Runbooks or reading Runbook Job logs
 * Access to [Settings](../settings.md)
 
@@ -146,6 +146,6 @@ This allows a user to create and publish notifications.
 This permission does not include:
 
 * Access to [User, Group and Device Management](../../ugd-management/user-group-device-management.md)
-* Access to [Application Management](/broken/pages/gEcwXq0N7AG3Ru0s348a)
+* Access to [Application Management](../../app-management/packages/README.md)
 * Starting Runbooks or reading Runbook Job logs
 * Access to [Settings](../settings.md)


### PR DESCRIPTION
## Summary

Fixes [#279](https://github.com/c4a8/c4a8-issues-products-realmjoin-internal/issues/279). The "Application Management" references linked to a removed GitBook page (`/broken/pages/gEcwXq0N7AG3Ru0s348a`), producing dead links.

## Changes

- **`realmjoin-settings/permission/pre-defined-roles.md`** — repointed all **6** "Application Management" links (Admin, Auditor, Software Agent, Software Requester, Organic Software Requester, Notification Agent role descriptions).
- **`introduction/navigation.md`** — fixed the same broken link on the "Application Management" section heading (found via a repo-wide search; it's the identical dead target).

All links now point to the **Packages overview** (`app-management/packages/README.md`).

## Design note

The issue asked for a more fine-grained fix and floated the idea of a dedicated "Overview" page. All six role references point at *Application Management as a whole* (each role grants or denies the entire area), so a single stable landing target is the right resolution. Rather than create a **duplicate** overview page, I pointed the links at the existing **Packages** page, which already serves as the section overview — it enumerates every sub-part (Package Store, Package Management, Deployment, Details, Settings, Packaging Requests, Migration Guide) via content-refs.

If you'd prefer a purpose-built `Application Management` overview/landing page instead, I'm happy to add one and repoint these links to it — just say the word.

Refs c4a8/c4a8-issues-products-realmjoin-internal#279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDJtHVdFkLZ9BNmhMLbPxD)_