### PR TITLE
docs: fix LAPS self-service accuracy against backend code

### DIFF
--- a/docs/realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/README.md
+++ b/docs/realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/README.md
@@ -125,10 +125,10 @@ Key `LocalAdminManagement.EmergencyAccount` (for common settings see [group sett
 
 ## Support account
 
-This account type can be configured for on-demand creation. It is designed for use in a limited time window of 12 hours in on-demand mode.
+This account type can be configured for on-demand creation. It is designed for use in a limited time window—12 hours by default—in on-demand mode. The expiration window can be adjusted per tenant in the _RealmJoin Portal_ (LAPS tenant configuration).
 
 {% hint style="danger" %}
-Support accounts and their profiles will be deleted 12 hours after requesting the account regardless of usage (after the support user has signed out). **All files will be permanently deleted.**
+Support accounts and their profiles will be deleted after the configured expiration window (12 hours by default) has elapsed since requesting the account, regardless of usage (after the support user has signed out). **All files will be permanently deleted.**
 {% endhint %}
 
 {% hint style="danger" %}
@@ -212,10 +212,6 @@ The value can also be pure boolean `true`/`false`. This may be used as a wildcar
 
 {% hint style="info" %}
 In the past it was recommended to set this setting to `true`. However, as we continue to expand RealmJoin, new account types will be added. It is therefore strongly recommended to migrate all `true` values to the more explicit object notation
-{% endhint %}
-
-{% hint style="info" %}
-Starting with **Portal v2026.29**, SelfLAPS can be scoped **per platform**, so you can grant self-service access to Windows and macOS devices independently.
 {% endhint %}
 
 A sample configuration may look like this:

--- a/docs/ugd-management/user-and-group-settings/additional-settings.md
+++ b/docs/ugd-management/user-and-group-settings/additional-settings.md
@@ -58,6 +58,23 @@ or specifically:
 }
 ```
 
+Starting with **Portal v2026.29**, access can be scoped **per platform** (Windows/macOS). A platform-specific property overrides the generic `CanReadPassword`/`CanRotatePassword` for the matching device platform:
+
+```
+{
+  "CanReadPasswordWindows": true,
+  "CanRotatePasswordWindows": true,
+  "CanReadPasswordMacOS": true,
+  "CanRotatePasswordMacOS": false
+}
+```
+
+A plain string value acts like `true` for the matching platform only:
+
+```
+"windows"|"macos"
+```
+
 ### Configure BranchCache for RJ packages
 
 This setting changes BranchCache mode for **new** clients.


### PR DESCRIPTION
## What & why

Verified the [LAPS page](https://docs.realmjoin.com/realmjoin-agent/realmjoin-client/local-admin-password-solution-laps) against the actual LAPS code and corrected the inaccuracies found.

Sources checked:
- `RealmJoin.Backend.Shared/LocalAdminManagement/*` (`StatusBuilder`, `AllowSelfLapsEntry`), `BackendDefaults.cs`, `TenantLapsConfig` in `realmjoin-complete`
- `RealmJoin.Shared/Config/ConfigLocalAdminManagement*.cs` and `LocalAdminManagementClientSettings.cs` (the account-type config model — identical between the pinned submodule commit and `main`)

## Changes

1. **Removed the "SelfLAPS can be scoped per platform" note from the LAPS page.** Per-platform (Windows/macOS) scoping is implemented only for **Intune LAPS** (`Allow.SelfLAPSIntune` → `StatusBuilder.CanSelfAdministerOwnDeviceIntuneAsync`). The RealmJoin LAPS self-service setting (`Allow.SelfLAPS` → `CanSelfAdministerOwnDeviceAsync`) has no platform dimension — it only understands `EmergencyAccount`/`SupportAccount`/`PrivilegedAccount` booleans or a plain boolean wildcard. The removed note was added speculatively in an earlier commit ("pending exact configuration syntax").
2. **Documented the per-platform Intune LAPS syntax where it actually applies** — under `Allow.SelfLAPSIntune` in `additional-settings.md` (`CanReadPasswordWindows`/`CanRotatePasswordWindows`/`CanReadPasswordMacOS`/`CanRotatePasswordMacOS`, plus the `"windows"`/`"macos"` string form).
3. **Clarified that the support-account 12h expiration is a default** that tenants can change in the Portal (`TenantLapsConfig.DefaultSupportAccountExpiration = 12`, editable via `EditTenantLapsConfig`). The page previously presented it as a hard-coded value.

## Verified accurate (no change needed)

The account-type config JSONs (Emergency / Support / Privileged) match the code model exactly — all property names and types (`NamePattern`, `DisplayName`, `PasswordCharSet`, `PasswordLength`, `PasswordPreset`, `MaxStaleness`, `OnDemand`, `Expiration`, `PasswordRenewals`) are current, and the example blocks use only valid properties per account type.

## Not changed — needs a product/agent-side check

These live in the RealmJoin agent (not in any accessible repo), so they were left as-is rather than edited on a guess:
- `LocalAdminManagement.CheckInterval` (default `"01:00"`) is not present in the shared config model nor in `realmjoin-complete`.
- The literal default values (`"ADM-{HEX:8}"`, the charset, length 20, preset 0) — the config classes have no default initializers; defaults are applied by the agent.
- The `PasswordRenewals` token `Yearly` is not mentioned in the model's token comment (which lists `DayAfterCreate`, `Weekly`/`Monthly`, weekdays, ISO timestamps).

## Risk

Docs-only, copy changes. No behavior/data impact. Worst case is a wording nuance needing a follow-up tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RjhC4HRU7NvTcGt2SnqLj

---
_Generated by [Claude Code](https://claude.ai/code/session_019RjhC4HRU7NvTcGt2SnqLj)_