### PR TITLE
Rework docs start page and add Overview page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,33 @@ description: Application Lifecycle and Management Companion to Microsoft Intune
 
 # RealmJoin Documentation
 
-[RealmJoin](https://realmjoin.com) is the perfect companion to Microsoft Intune. Securely connect to the cloud and manage large ecosystems with software and policies as well as your Entra ID based user landscape - without any on-premise servers or other local requirements.\
+[RealmJoin](https://realmjoin.com) is the perfect companion to Microsoft Intune. Deploy and maintain software from a curated catalogue of more than 3,000 applications, manage your Entra ID users, groups and devices in one unified view, and automate everyday IT operations - all cloud-native, without any on-premise servers or other local requirements.\
 Manage software lifecycle, devices and users & start with automation - no matter if work happens in corporate headquarters or at [Starbucks](https://www.starbucks.com).
 
 <figure><img src=".gitbook/assets/RealmJoin-logo.png" alt=""><figcaption></figcaption></figure>
+
+These docs cover the technical aspects of RealmJoin, from onboarding your tenant to the reference for every runbook. Everything else about the product can be found on the [RealmJoin website](https://www.realmjoin.com/).
+
+## New to RealmJoin?
+
+<table data-view="cards"><thead><tr><th></th><th></th><th data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Overview</strong></td><td>What RealmJoin is, which problems it solves and how it complements Microsoft Intune.</td><td><a href="overview.md">overview.md</a></td></tr><tr><td><strong>Architecture Overview</strong></td><td>The cloud backend, how devices and administrators connect, and which resources RealmJoin uses in your own tenant.</td><td><a href="deployment/architecture-overview.md">architecture-overview.md</a></td></tr><tr><td><strong>Portal Navigation</strong></td><td>A guided tour through the RealmJoin Portal and everything you can reach from it.</td><td><a href="introduction/navigation.md">navigation.md</a></td></tr></tbody></table>
+
+## Set up your environment
+
+<table data-view="cards"><thead><tr><th></th><th></th><th data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Getting Started</strong></td><td>Decide which deployment guide fits your scope - standard for a trial or Intune-only setup, extended for the full feature set.</td><td><a href="deployment/getting-started/">getting-started</a></td></tr><tr><td><strong>Onboarding</strong></td><td>Onboard RealmJoin Portal to your Entra ID tenant using Quick or Advanced Setup.</td><td><a href="deployment/onboarding-realmjoin-portal/">onboarding-realmjoin-portal</a></td></tr><tr><td><strong>Required Permissions</strong></td><td>Every permission RealmJoin requests, and what each of them is used for.</td><td><a href="deployment/required-permissions.md">required-permissions.md</a></td></tr><tr><td><strong>Deploying the Agent</strong></td><td>Roll out the optional RealmJoin Agent to your Windows clients.</td><td><a href="realmjoin-agent/installation.md">installation.md</a></td></tr></tbody></table>
+
+## Explore by area
+
+<table data-view="cards"><thead><tr><th></th><th></th><th data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Application Management</strong></td><td>Package Store, subscriptions, assignments, update channels and packaging requests.</td><td><a href="application-management/packages/">packages</a></td></tr><tr><td><strong>User, Group &#x26; Device Management</strong></td><td>Entra ID, Intune, Defender, Autopilot and sign-in data correlated in a single view.</td><td><a href="ugd-management/user-group-device-management.md">user-group-device-management.md</a></td></tr><tr><td><strong>Automation</strong></td><td>Runbooks that run in your own Azure Automation account, plus Intune remediation scripts.</td><td><a href="automation/runbooks/">runbooks</a></td></tr><tr><td><strong>RealmJoin Agent</strong></td><td>ESP, dependency-aware app deployment, LAPS, notifications and self service on the device.</td><td><a href="realmjoin-agent/realmjoin-client/">realmjoin-client</a></td></tr><tr><td><strong>Analyze &#x26; Export</strong></td><td>Advanced search, software reporting and data export.</td><td><a href="analyze-and-export/advanced-search/">advanced-search</a></td></tr><tr><td><strong>Administration &#x26; Settings</strong></td><td>Roles and permissions, group namespaces, self service forms and third-party integrations.</td><td><a href="administration-and-settings/settings.md">settings.md</a></td></tr><tr><td><strong>Security &#x26; Privacy</strong></td><td>Data handling, tenant separation and hosting.</td><td><a href="security-and-privacy/security-and-privacy.md">security-and-privacy.md</a></td></tr><tr><td><strong>Developer Reference</strong></td><td>RealmJoin API, runbook development and report functions.</td><td><a href="dev-reference/realmjoin-api/">realmjoin-api</a></td></tr></tbody></table>
+
+## Stay up to date and get help
+
+* **What's new:** the [RealmJoin Changelog](https://feedback.realmjoin.com/) lists new features and fixes - and takes your feature requests.
+* **Questions:** browse the [FAQ](troubleshooting-and-faq/faq.md) and [Troubleshooting](troubleshooting-and-faq/troubleshooting/) sections.
+* **Support:** [Support & Service Level](legal/support.md) explains how to reach us and which response times apply.
+* **Watch and learn:** [RealmJoin Unlocked](introduction/realmjoin-unlocked-vodcast.md), our video podcast series.
+* **Bookmarks:** the most important RealmJoin addresses are collected under [Useful Links](introduction/useful-links.md).
+
+{% hint style="info" %}
+Ready to jump in? [RealmJoin Portal](https://portal.realmjoin.com) is where all administration happens.
+{% endhint %}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,6 +1,7 @@
 # Table of contents
 
 * [RealmJoin Documentation](README.md)
+* [Overview](overview.md)
 
 ## Introduction
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,101 @@
+---
+type: Introduction
+description: >-
+  What RealmJoin is, which problems it solves next to Microsoft Intune, and what
+  you need to run it.
+---
+
+# Overview
+
+## What is RealmJoin?
+
+RealmJoin is a **cloud-native, multi-tenant SaaS** and the **Application Lifecycle and Management companion to Microsoft Intune**. It is developed and operated by [glueckkanja](https://www.glueckkanja.com/) in Microsoft Azure, hosted in Europe, and requires **no on-premise servers and no local infrastructure**.
+
+RealmJoin does not replace Intune - it builds on it. Intune stays your MDM: it enrolls devices, applies compliance and configuration policies, and delivers apps. RealmJoin adds what modern workplace teams need on top of it:
+
+* a maintained **application catalogue and packaging service**, so you stop building and updating packages yourself,
+* a **single, correlated view** of users, groups and devices across Intune, Entra ID, Microsoft Defender, Windows Autopilot and sign-in logs,
+* **process automation** through curated runbooks that run in your own Azure Automation account,
+* **delegated administration and self service**, so helpdesk staff and end users can act without broad Intune or Entra admin roles.
+
+Administrators work in the [RealmJoin Portal](https://portal.realmjoin.com); on Windows clients, the optional [RealmJoin Agent](realmjoin-agent/realmjoin-client/) adds deployment and self-service capabilities directly on the device.
+
+## What RealmJoin covers
+
+### Application Management
+
+The [Package Store](application-management/packages/package-store/) contains a continuously maintained catalogue of more than 3,000 ready-to-use Windows and macOS application packages. You subscribe to the packages you need, assign them to managed groups, and RealmJoin keeps versions and update channels (Preview / Main) flowing.
+
+* **Generic packages** are maintained for all customers; **custom** and **organic packages** cover applications specific to your environment - and if something is missing, you can raise a [packaging request](application-management/packages/packaging-requests/) instead of packaging it yourself.
+* Each package can be delivered either as an **Intune deployment** (`intunewin` pushed into your tenant) or as a **RealmJoin deployment** through the Agent. See [Deployment Methods](application-management/deployment-methods.md) for the comparison; macOS packages are provisioned via Intune.
+* With RealmJoin deployment you additionally get **package dependencies and install order**, auto-upgrades for _Available_ apps, self-service reinstall/repair, user deferral options and reliable delivery of very large payloads.
+
+{% content-ref url="application-management/packages/" %}
+[packages](application-management/packages/)
+{% endcontent-ref %}
+
+### User, Group and Device Management
+
+RealmJoin merges data from several Microsoft services into **one view per object**. On a device you see its Intune state next to Autopilot registration, Defender risk and sign-in activity; on a user you see licenses, group memberships, devices and policies - without switching portals.
+
+From there you can drill down across correlated objects, run [Advanced Search](analyze-and-export/advanced-search/) queries, export data, and trigger context-specific actions directly on the object.
+
+{% content-ref url="ugd-management/user-group-device-management.md" %}
+[user-group-device-management.md](ugd-management/user-group-device-management.md)
+{% endcontent-ref %}
+
+### Process Automation
+
+[Runbooks](automation/runbooks/) automate the recurring tasks of a modern workplace: onboarding and offboarding, group and mailbox management, device outphasing and wiping, Autopilot cleanup, reporting, security responses such as isolating a device or reading out BitLocker and LAPS secrets.
+
+The runbook library is kept in sync from a [public GitHub repository](https://github.com/realmjoin/realmjoin-runbooks) and executed in **your own Azure Automation account** under a managed identity you control - you can add your own runbooks alongside it. Scheduled runbooks cover recurring reports and cleanups, and every job is logged and auditable.
+
+{% content-ref url="automation/runbooks/" %}
+[runbooks](automation/runbooks/)
+{% endcontent-ref %}
+
+### RealmJoin Agent
+
+The [RealmJoin Agent](realmjoin-agent/realmjoin-client/) is an optional Windows 10/11 component. It applies the software and configuration policy assigned to a device after a local security assessment, and adds features that Intune alone does not offer:
+
+* the [RealmJoin ESP](realmjoin-agent/realmjoin-client/realmjoin-esp.md), which holds the desktop until mandatory apps are installed - honouring dependencies and order,
+* a [Self Service Portal](realmjoin-agent/client-menu/self-service-portal.md) and [tray menu](realmjoin-agent/client-menu/realmjoin-tray.md) for user-initiated installs,
+* [LAPS](realmjoin-agent/realmjoin-client/local-admin-password-solution-laps/) with passwords stored in your own Azure Key Vault,
+* [user notifications](realmjoin-agent/realmjoin-client/showing-notifications.md), [multi-user shared devices](realmjoin-agent/realmjoin-client/multi-user-devices.md) and [AnyDesk integration](realmjoin-agent/realmjoin-client/anydesk-integration/).
+
+{% content-ref url="realmjoin-agent/installation.md" %}
+[installation.md](realmjoin-agent/installation.md)
+{% endcontent-ref %}
+
+### Delegation, self service and auditing
+
+* **[Roles and Permissions](administration-and-settings/permission/):** delegate portal functionality to Entra users and groups with pre-defined or custom roles, optionally combined with [Privileged Identity Management](administration-and-settings/permission/implementing-privileged-identity-management-pim-with-realmjoin-portal.md). Helpdesk teams get exactly the actions they need - nothing more.
+* **Self service:** every user has access to their own [profile page](ugd-management/user-profile.md), and [Self Service Forms](administration-and-settings/self-service-forms.md) collect structured requests such as incident reports or equipment orders.
+* **[Audit Log](monitoring-and-logs/audit-log.md):** all actions performed in the portal are written to a Log Analytics workspace in your own Azure environment.
+
+## How it works
+
+RealmJoin's backend runs in Microsoft Azure and connects to your tenant through **least-privilege Entra ID applications** that you consent to during onboarding. Sensitive workloads deliberately stay in your environment: runbooks execute in your Azure Automation account, LAPS passwords live in your Azure Key Vault, and audit logs go to your Log Analytics workspace.
+
+{% content-ref url="deployment/architecture-overview.md" %}
+[architecture-overview.md](deployment/architecture-overview.md)
+{% endcontent-ref %}
+
+## What you need
+
+* A **Microsoft 365 / Entra ID tenant** with **Microsoft Intune** licenses. RealmJoin is licensed per user, based on the Intune user license seats in your tenant - see [Licensing](legal/licensing/).
+* A **Global Administrator** to consent to the RealmJoin applications during [onboarding](deployment/onboarding-realmjoin-portal/). Quick Setup covers core portal functionality; Advanced Setup unlocks the full feature set, including Autopilot, the Agent, privileged device actions, LAPS, audit logs and security features.
+* An **Azure subscription** for the resources RealmJoin uses in your own environment: Azure Automation for runbooks, Key Vault for LAPS passwords and Log Analytics for audit and runbook logs. Expected Azure cost is minimal - see the [FAQ](troubleshooting-and-faq/faq.md#what-cost-to-expect-from-azure-resources).
+* Optional: the **RealmJoin Agent** on Windows 10/11 clients for RealmJoin-based app deployment and the Agent-exclusive features. Microsoft Defender for Endpoint features require the corresponding Microsoft license.
+
+{% hint style="info" %}
+No on-premise servers, agents for the backend, or network appliances are required at any point.
+{% endhint %}
+
+## Getting started
+
+Pick the deployment guide that matches your scope and follow it end to end - from consenting to the RealmJoin applications to your first package assignment.
+
+{% content-ref url="deployment/getting-started/" %}
+[getting-started](deployment/getting-started/)
+{% endcontent-ref %}


### PR DESCRIPTION
Addresses c4a8/c4a8-issues-products-realmjoin-internal#281 — the old Welcome page was outdated and not a real entry point into the docs. Structure follows the [SCEPman](https://github.com/scepman/scepman-docs/blob/master/docs/README.md) and [RADIUSaaS](https://github.com/RADIUS-as-a-Service/radiusaas-docs/blob/main/docs/README.md) docs referenced in the issue: a landing page plus an `Overview` page directly beneath it.

## Landing page (`docs/README.md`)

* Sharpened the opening pitch (catalogue of 3,000+ apps, unified user/group/device view, automation, no on-premise requirements) while keeping the existing tone, the RealmJoin logo figure and the description frontmatter.
* Added card sections that route readers where they want to go:
  * **New to RealmJoin?** — Overview, Architecture Overview, Portal Navigation
  * **Set up your environment** — Getting Started, Onboarding, Required Permissions, Deploying the Agent
  * **Explore by area** — one card per documentation section (Application Management, UGD Management, Automation, Agent, Analyze & Export, Administration & Settings, Security & Privacy, Developer Reference)
* Added a "Stay up to date and get help" block linking changelog, FAQ, Troubleshooting, Support & Service Level, RealmJoin Unlocked and Useful Links, plus a hint pointing at the portal.

## New Overview page (`docs/overview.md`)

Answers the basic first question — *What is RealmJoin?* — and how it relates to Intune:

* **What is RealmJoin?** — cloud-native SaaS, companion to (not replacement for) Intune, no on-premise infrastructure.
* **What RealmJoin covers** — Application Management, User/Group/Device Management, Process Automation, the optional RealmJoin Agent, and delegation/self service/auditing, each with content-refs into the respective section.
* **How it works** — least-privilege Entra applications, sensitive workloads (runbooks, LAPS, audit logs) staying in the customer tenant, pointing to the Architecture Overview.
* **What you need** — tenant and Intune licensing, Global Admin consent with Quick vs. Advanced Setup, the Azure resources used, and optional components.
* **Getting started** — content-ref to the deployment guides.

All statements are sourced from existing pages in this repo (architecture overview, deployment methods, onboarding, agent features, roles & permissions, licensing, FAQ) — no new product claims.

## Navigation

`SUMMARY.md` gets a single new root-level entry `* [Overview](overview.md)` directly after the landing page, matching the sibling products' structure. No pages were moved or renamed, so no redirects were needed.

All internal links and the FAQ anchor in both pages were verified against the file tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq99HSNxkUjrQ7Ph3tHrVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq99HSNxkUjrQ7Ph3tHrVD)_