### PR TITLE
Document App Catalog display name customization

### DIFF
--- a/docs/realmjoin-agent/client-menu/realmjoin-tray.md
+++ b/docs/realmjoin-agent/client-menu/realmjoin-tray.md
@@ -28,3 +28,12 @@ A further useful feature is **Sync this device:**
 ![](<../../.gitbook/assets/image (106).png>)
 
 When you click **Sync this device** RealmJoin will install or update mandatory packages. Furthermore, **Sync this device** helps to speed up background processes (e. g. waiting for new weblinks or waiting for an admin account).
+
+## App Catalog Entry
+
+The tray menu can also show an **App Catalog** entry that opens the device's [App Catalog](self-service-portal.md#app-catalog-tab) directly. This entry is enabled and customized via the [`AppCatalog`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) client setting:
+
+* Enable it with `AppCatalog.Enabled`.
+* Rename the entry with [`AppCatalog.Ui.DisplayName`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) (defaults to `"App Catalog"`).
+
+See [One-Click Access: Self-Service Portal from the Tray](self-service-portal.md#one-click-access-self-service-portal-from-the-tray) for details.

--- a/docs/realmjoin-agent/client-menu/self-service-portal.md
+++ b/docs/realmjoin-agent/client-menu/self-service-portal.md
@@ -113,6 +113,7 @@ The App Catalog can be opened directly from the tray menu and, optionally, from 
 
 * Enable the [`AppCatalog.Enabled`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) setting to add an **App Catalog** entry to the RealmJoin tray menu, opening the device's App Catalog page in Microsoft Edge's app mode (a clean, chromeless window).
 * Additionally enable `AppCatalog.CreateStartMenuShortcut` to also create a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.
+* Use [`AppCatalog.Ui.DisplayName`](https://docs.realmjoin.com/ugd-management/user-and-group-settings/additional-settings#appcatalog-feature) to rename the tray menu entry (and Start Menu shortcut) if the default caption "App Catalog" does not fit your naming conventions.
 
 Both entries dynamically resolve the current device and signed-in user at launch, so they work across all Entra-joined devices without per-device customization.
 

--- a/docs/ugd-management/user-and-group-settings/additional-settings.md
+++ b/docs/ugd-management/user-and-group-settings/additional-settings.md
@@ -412,13 +412,17 @@ AppCatalog
 {
   "Enabled": true | false,
   "HidePackages": true | false,
-  "CreateStartMenuShortcut": true | false
+  "CreateStartMenuShortcut": true | false,
+  "Ui": {
+    "DisplayName": "App Catalog"
+  }
 }
 ```
 
 * **Enabled:** Adds an **App Catalog** entry to the RealmJoin tray menu that opens the device's App Catalog page in Microsoft Edge app mode.
 * **HidePackages:** Hides the individual software packages from the classic tray "Install"/"Update" submenu, useful once users are directed to the App Catalog instead.
 * **CreateStartMenuShortcut:** Requires `Enabled: true`. Creates a per-user Start Menu shortcut ("App Catalog") that opens the same page, so it can be found via Start search or pinned to the taskbar.
+* **Ui.DisplayName:** Caption of the App Catalog entry in the RealmJoin tray menu. The same text is also used for the Start Menu shortcut created by `CreateStartMenuShortcut`. Defaults to `"App Catalog"`.
 
 ### Weblinks for RealmJoin Tray
 


### PR DESCRIPTION
## Summary
This PR adds documentation for the `AppCatalog.Ui.DisplayName` setting, which allows administrators to customize the caption of the App Catalog entry in the RealmJoin tray menu and Start Menu shortcut.

## Changes
- **realmjoin-tray.md**: Added new "App Catalog Entry" section explaining how to enable and customize the App Catalog tray menu entry, with references to the configuration setting and related documentation.
- **additional-settings.md**: Extended the `AppCatalog` configuration schema to include the new `Ui.DisplayName` property and documented its purpose and default value.
- **self-service-portal.md**: Added documentation about using `AppCatalog.Ui.DisplayName` to customize the tray menu entry and Start Menu shortcut captions.

## Details
The changes document a new customization capability that allows organizations to rename the App Catalog entry to match their naming conventions. The documentation includes:
- Configuration schema updates showing the nested `Ui` object structure
- Clear explanation of the default behavior ("App Catalog")
- Cross-references between related documentation pages for discoverability

https://claude.ai/code/session_01HzJ8qR4n1wMrQeouazpVyf