### PR TITLE
update checkout action version to v7.0.1 in workflow

### DIFF
--- a/.github/workflows/update-runbook-references.yml
+++ b/.github/workflows/update-runbook-references.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout Documentation Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ssh-key: ${{ secrets.update_runbook_references }}
           
       - name: 📥 Checkout RealmJoin Runbooks Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: realmjoin/realmjoin-runbooks
           ref: production


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a specific commit of the `actions/checkout` action, ensuring consistency and reproducibility in CI runs.

Dependency update:

* Updated both checkout steps in `.github/workflows/update-runbook-references.yml` to use `actions/checkout` at the pinned commit `3d3c42e5aac5ba805825da76410c181273ba90b1` (corresponding to v7.0.1), instead of the floating `@v6` version.