### PR TITLE
Add AVD template best practices documentation

### DIFF
--- a/docs/deployment/infrastructure/avd-templates.md
+++ b/docs/deployment/infrastructure/avd-templates.md
@@ -92,6 +92,28 @@ Please handle the token with care. If you think the token might have been leaked
 
 <figure><img src="../../.gitbook/assets/image-6.png" alt=""><figcaption><p>Create a token</p></figcaption></figure>
 
+## Best practices
+
+Follow these recommendations to keep your AVD templates stable and avoid packages being unexpectedly removed from a template.
+
+### Use a dedicated package subscription per app
+
+Always create a **separate package subscription** for each application you add to a template and rename it to `AVD - [PACKAGENAME]`.
+
+{% hint style="warning" %}
+Never reuse an existing (non-AVD) app subscription in a template. Packages used in AVD templates are handled differently from regular deployments, so sharing a subscription between both can lead to unexpected behavior.
+{% endhint %}
+
+### Only enable automation on the main channel
+
+Enable automation on the **main** channel only — never on the **preview** channel.
+
+{% hint style="danger" %}
+There are no preview options for AVD, and switching a subscription from **preview** to **main** creates a **new** subscription. This deletes the existing package and rebuilds it, which removes the package from any template it was part of.
+
+Updating from **main** to **main** does not create a new subscription, so the package stays in the template.
+{% endhint %}
+
 ## Using a Template
 
 ### AVD / Headless Provisioning


### PR DESCRIPTION
## Summary
Added a new "Best practices" section to the AVD templates documentation to help users maintain stable templates and avoid common issues with package management.

## Changes
- Added comprehensive best practices guidance for AVD template management
- Documented the requirement to use dedicated package subscriptions per application with `AVD - [PACKAGENAME]` naming convention
- Explained the risks of reusing non-AVD app subscriptions in templates
- Clarified automation channel requirements (main channel only, never preview)
- Documented the critical issue where switching from preview to main channel creates a new subscription and removes packages from templates
- Noted that main-to-main updates preserve packages in templates

## Details
The new section includes two main recommendations with supporting warning and danger callouts to highlight important considerations for users managing AVD templates. This guidance helps prevent unexpected package removal and subscription conflicts.

https://claude.ai/code/session_01H6ViEuZFbUBLYRpg3Vvr54