### PR TITLE
docs: rework Infrastructure Considerations (endpoints, Azure Front Door, proxies, BranchCache)

### DIFF
--- a/docs/deployment/infrastructure/README.md
+++ b/docs/deployment/infrastructure/README.md
@@ -18,7 +18,7 @@ RealmJoin is a cloud-native service and is designed for **direct, unrestricted o
 
 ### RealmJoin Connection Endpoints
 
-Allow outbound HTTPS (TCP 443) to the following hosts in your firewall and proxy configuration:
+The RealmJoin client requires outbound HTTPS (TCP 443) and must be able to reach all of the following endpoints:
 
 | Host                                | Purpose                                          |
 | ----------------------------------- | ------------------------------------------------ |
@@ -34,16 +34,16 @@ Allow outbound HTTPS (TCP 443) to the following hosts in your firewall and proxy
 | `x1.c.lencr.org`                    | Certificate validation (Let's Encrypt)           |
 
 {% hint style="warning" %}
-Always allow these endpoints **by hostname (FQDN), never by IP address**. RealmJoin services are published via Azure Front Door, which has no fixed IP ranges — see [Azure Front Door](#azure-front-door) below. **We cannot provide IP addresses or IP ranges for RealmJoin, and IP-based filtering is not supported.**
+Reference these endpoints **by hostname (FQDN), never by IP address**. **We cannot provide IP addresses or IP ranges for RealmJoin, and IP-based filtering is not supported.** The package CDN (`cdn.realmjoin.com`) is delivered via Azure Front Door, which has no fixed IP ranges — see [Azure Front Door](#azure-front-door) below.
 {% endhint %}
 
 ### Azure Front Door
 
-RealmJoin services — including the package CDN — are delivered through [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview), Microsoft's global edge and CDN platform. This has direct consequences for network filtering:
+`cdn.realmjoin.com` — the endpoint that delivers all software package content — is served through [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview), Microsoft's global edge and CDN platform. This has direct consequences for network filtering:
 
-* **There are no fixed IP ranges.** Azure Front Door uses a Microsoft-managed, global anycast IP pool. Microsoft can add, remove, or reassign these IP addresses at any time without notice. For this reason, no IP list for RealmJoin exists or can be provided — any such list would be immediately outdated.
-* **IP-based allowlisting is not supported** and will break without warning when Microsoft changes the Front Door infrastructure. The same applies to DNS-level interception or rewriting of these hostnames.
-* **FQDN-based filtering** of the hostnames listed above is the only supported way to restrict RealmJoin traffic.
+* **There are no fixed IP ranges.** Azure Front Door uses a Microsoft-managed, global anycast IP pool. Microsoft can add, remove, or reassign these IP addresses at any time without notice. For this reason, no IP list exists or can be provided — any such list would be immediately outdated.
+* **IP-based allowlisting will break without warning** and is not supported. The same applies to DNS-level interception or rewriting of these hostnames.
+* If your policy requires restricting outbound traffic regardless, **hostname (FQDN) based rules** are the only approach that works with RealmJoin.
 
 ### Avoid Proxies
 

--- a/docs/deployment/infrastructure/README.md
+++ b/docs/deployment/infrastructure/README.md
@@ -1,72 +1,86 @@
 ---
 type: Deployment Guide
 description: >-
-  RealmJoin infrastructure and network requirements, including proxy guidance and
-  the Azure and Office 365 IP ranges that must be reachable.
+  RealmJoin infrastructure and network requirements: connection endpoints,
+  Azure Front Door, proxy guidance, and BranchCache-based peer-to-peer content
+  delivery.
 ---
 
 # Infrastructure Considerations
 
 ## Network
 
-### Avoid Proxies
+### RealmJoin Connection Endpoints
 
-Initial deployment needs direct internet access. No proxy would be ideal, but a transparent proxy should work fine (if truly transparent). If a proxy is unavoidable as a minimum requirement the following services/addresses need to be directly accessible:
+RealmJoin communicates exclusively via HTTPS (TCP 443). Allow the following hosts in your firewall and proxy configuration:
 
-For a list of the corresponding IP ranges click the following link:
+| Host                                | Purpose                                          |
+| ----------------------------------- | ------------------------------------------------ |
+| `client-api.realmjoin.com`          | RealmJoin client backend API                     |
+| `client-api-staging.realmjoin.com`  | RealmJoin client backend API (staging)           |
+| `cdn.realmjoin.com`                 | Software package content delivery                |
+| `nuget.realmjoin.com`               | RealmJoin package feed (NuGet)                   |
+| `gkrealmjoin.s3.amazonaws.com`      | RealmJoin client download                        |
+| `realmjoinstaticcdn.azureedge.net`  | RealmJoin Notifier                               |
+| `login.microsoftonline.com`         | Microsoft Entra ID authentication                |
+| `graph.microsoft.com`               | Microsoft Graph API                              |
+| `enterpriseregistration.windows.net`| Microsoft Entra device registration              |
+| `x1.c.lencr.org`                    | Certificate validation (Let's Encrypt)           |
 
-[Azure IP Ranges and Service Tags – Public Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
-
-This file contains the compute IP address ranges (including SQL ranges) used by the Microsoft Azure Datacenters. A new xml file will be uploaded every Wednesday (Pacific Time) with the new planned IP address ranges. New IP address ranges will be effective on the following Monday (Pacific Time).\
-Download the new xml file and perform the necessary changes on your site before Monday.
-
-[Office 365 URLs and IP address ranges](https://support.office.com/en-us/article/Office-365-URLs-and-IP-address-ranges-8548a211-3fe7-47cb-abb1-355ea5aa88a2)
-
-This article links a file that contains the compute IP address ranges that you should include in your outbound allow lists to ensure your computers can successfully use Office 365.
-
-{% hint style="info" %}
-IP addresses filtering alone is not a complete solution due to dependencies on internet-based services such as Domain Name Services (DNS), Content Delivery Networks (CDNs), Certificate Revocation Lists and other third party or dynamic services. These dependencies include dependencies on other Microsoft services such as the Azure Content Delivery Network and will result in network traces or firewall logs indicating connections to IP addresses owned by third parties or Microsoft but not listed on this page. These unlisted IP addresses, whether from third party or Microsoft owned CDN and DNS services, are dynamically assigned and can change at any time.
+{% hint style="warning" %}
+Always allow these endpoints **by hostname (FQDN), not by IP address**. RealmJoin services are published via Azure Front Door, which has no fixed IP ranges — see [Azure Front Door](#azure-front-door) below.
 {% endhint %}
 
-### BranchCache and Device isolation
+### Azure Front Door
 
-BranchCache is a Windows technology designed to **reduce WAN traffic** and **speed up content delivery** inside corporate networks. It does this by allowing Windows clients to share downloaded data with each other, instead of every device pulling the same content repeatedly from the cloud.
+RealmJoin services are delivered through [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview), Microsoft's global edge and CDN platform. This has direct consequences for network filtering:
+
+* **No fixed IP ranges**: Azure Front Door uses a Microsoft-managed, global anycast IP pool. Microsoft can add, remove, or reassign these IP addresses at any time without notice.
+* **Do not allowlist IP addresses** for RealmJoin endpoints. IP-based rules will break without warning when Microsoft changes the Front Door infrastructure.
+* **Use FQDN-based filtering** (hostnames listed above) in firewalls and proxies instead.
+* If your firewall supports **Azure service tags**, the `AzureFrontDoor.Frontend` service tag covers Front Door's edge ranges and is updated by Microsoft automatically. This is the only supported alternative to FQDN-based rules.
+
+### Avoid Proxies
+
+* Initial deployment requires **direct internet access**.
+* **No proxy** is ideal; a **transparent proxy** works fine (if truly transparent).
+* If a proxy is unavoidable, the [RealmJoin connection endpoints](#realmjoin-connection-endpoints) must be directly accessible as a minimum requirement.
+
+In addition, the Microsoft services RealmJoin depends on must be reachable. Microsoft publishes the corresponding address ranges:
+
+* [Azure IP Ranges and Service Tags – Public Cloud](https://www.microsoft.com/en-us/download/details.aspx?id=56519) — compute IP address ranges (including SQL ranges) used by the Microsoft Azure datacenters. A new file is uploaded every Wednesday (Pacific Time) with the planned IP address ranges, effective the following Monday (Pacific Time). Download the new file and apply the necessary changes on your site before Monday.
+* [Office 365 URLs and IP address ranges](https://support.office.com/en-us/article/Office-365-URLs-and-IP-address-ranges-8548a211-3fe7-47cb-abb1-355ea5aa88a2) — address ranges to include in your outbound allow lists so clients can successfully use Office 365.
+
+{% hint style="info" %}
+IP address filtering alone is not a complete solution due to dependencies on internet-based services such as Domain Name Services (DNS), Content Delivery Networks (CDNs), Certificate Revocation Lists and other third party or dynamic services. These dependencies include dependencies on other Microsoft services such as the Azure Content Delivery Network and will result in network traces or firewall logs indicating connections to IP addresses owned by third parties or Microsoft but not listed on this page. These unlisted IP addresses, whether from third party or Microsoft owned CDN and DNS services, are dynamically assigned and can change at any time.
+{% endhint %}
+
+### BranchCache and Device Isolation
+
+BranchCache is a built-in Windows peering technology that **reduces WAN traffic** and **speeds up content delivery** by letting clients share downloaded content with each other instead of every device pulling the same content from the cloud.
 
 {% hint style="info" %}
 For RealmJoin, BranchCache is **enabled by default** on CDN and client side.
 {% endhint %}
 
-Why not use Delivery Optimization? This mechanism does not support third‑party package sources. It works only with Microsoft‑controlled endpoints (e.g.: Windows Update, Store, M365 Apps or Intune).
+**Why BranchCache instead of Delivery Optimization?** Delivery Optimization does not support third-party package sources — it works only with Microsoft-controlled endpoints (Windows Update, Store, M365 Apps, Intune). BranchCache works for third-party content such as RealmJoin packages.
 
-So within RealmJoin, we rely on BranchCache because it is a **built‑in Windows peering mechanism** that works for third‑party content:
+**Configuration:**
 
-* **CDN side**: It is enabled by default. If requested, we can disable BranchCache entirely on the CDN side (per tenant), which makes the client‑side configuration irrelevant.
-* On the **client side**, the feature is enabled by default as well. By setting `BranchCache.Mode = "Undefined"` (see [User and Group Settings](../../ugd-management/user-and-group-settings/)), this default behaviour can be changed. However, for existing clients, the feature will not be actively disabled once it has been activated before. To disable, run `Disable-BC` on the desired devices.
+* **CDN side**: Enabled by default. On request, we can disable BranchCache entirely on the CDN side (per tenant), which makes the client-side configuration irrelevant.
+* **Client side**: Enabled by default. Set `BranchCache.Mode = "Undefined"` (see [User and Group Settings](../../ugd-management/user-and-group-settings/)) to change this default. Note: on existing clients, the feature is not actively disabled once it has been activated before — run `Disable-BC` on the desired devices to disable it.
 
-For BranchCache to be effective, the clients need to be able to communicate directly with each other. So, they should not be separated by different VLANs, subnets or communication blocked via device isolation. We use BranchCache in **Distributed Cache Mode**, where every client maintains a local cache and retrieves cached data from peers. The option **Hosted Cache Mode**, which requires a dedicated Windows Server and is configured on clients via the "Configure Hosted Cache Servers" policy, is **not supported** by RealmJoin.
+**Network requirements:**
 
-When a client device downloads software packages for the first time, the files are divided into chunks that are significantly smaller than the original content and cached on the device.  If the same package is afterwards requested from a different client device in the same network, it downloads content information instead of the complete content from the server. The content information is used to locate the desired content on other devices in the network. **Client peer discovery** in "Distributed Cache Mode" works as follows:
+* Clients must be able to **communicate directly with each other** — do not separate them into different VLANs or subnets, and do not block peer traffic via device isolation.
+* RealmJoin uses **Distributed Cache Mode** only: every client maintains a local cache and retrieves cached data from peers.
+* **Hosted Cache Mode** (dedicated Windows Server, configured via the "Configure Hosted Cache Servers" policy) is **not supported** by RealmJoin.
 
-* A client sends a multicast query such as "Does anyone have content ID XYZ?"
-* Any peer that holds the requested segment responds directly via uni-cast.
+**How it works:**
 
-Instead of downloading packages from the server, the content in form of the chopped up chunks is transferred to the client device. If the requested software is available on several devices, the load is balanced between them.
+1. When a client downloads a software package for the first time, the files are divided into chunks significantly smaller than the original content and cached on the device.
+2. When another client in the same network requests the same package, it downloads only **content information** instead of the complete content from the server.
+3. The client uses the content information for **peer discovery**: it sends a multicast query ("Does anyone have content ID XYZ?"), and any peer holding the requested segment responds directly via unicast.
+4. The content is transferred from peers as chunks. If the requested software is available on several devices, the load is balanced between them.
 
 For more details see Microsoft Learn: [BranchCache](https://learn.microsoft.com/en-us/windows-server/networking/branchcache/branchcache)
-
-### RealmJoin Connection Endpoints
-
-RealmJoin connects to the following hosts (using HTTPS) that might be considered in your firewall settings:
-
-* `cdn.realmjoin.com`
-* `x1.c.lencr.org`
-* `client-api.realmjoin.com`
-* `client-api-staging.realmjoin.com`
-* `realmjoin-backend.azurewebsites.net`
-* `realmjoin-backend-staging.azurewebsites.net`
-* `nuget.realmjoin.com`
-* `enterpriseregistration.windows.net`
-* `gkrealmjoin.s3.amazonaws.com`
-* `login.microsoftonline.com`
-* `graph.microsoft.com`
-* `realmjoinstaticcdn.azureedge.net` (Notifier)

--- a/docs/deployment/infrastructure/README.md
+++ b/docs/deployment/infrastructure/README.md
@@ -10,9 +10,15 @@ description: >-
 
 ## Network
 
+RealmJoin is a cloud-native service and is designed for **direct, unrestricted outbound internet access**. This is the supported configuration. If your security policy requires outbound filtering, follow the rules below — they contain everything needed to configure a firewall for RealmJoin:
+
+* **Direction**: Outbound only. All connections are initiated by the client; no inbound rules are required.
+* **Protocol**: HTTPS (TCP 443) exclusively.
+* **Filtering**: By **hostname (FQDN)** only — see the endpoint list below. **IP-based filtering is not supported.**
+
 ### RealmJoin Connection Endpoints
 
-RealmJoin communicates exclusively via HTTPS (TCP 443). Allow the following hosts in your firewall and proxy configuration:
+Allow outbound HTTPS (TCP 443) to the following hosts in your firewall and proxy configuration:
 
 | Host                                | Purpose                                          |
 | ----------------------------------- | ------------------------------------------------ |
@@ -28,17 +34,16 @@ RealmJoin communicates exclusively via HTTPS (TCP 443). Allow the following host
 | `x1.c.lencr.org`                    | Certificate validation (Let's Encrypt)           |
 
 {% hint style="warning" %}
-Always allow these endpoints **by hostname (FQDN), not by IP address**. RealmJoin services are published via Azure Front Door, which has no fixed IP ranges — see [Azure Front Door](#azure-front-door) below.
+Always allow these endpoints **by hostname (FQDN), never by IP address**. RealmJoin services are published via Azure Front Door, which has no fixed IP ranges — see [Azure Front Door](#azure-front-door) below. **We cannot provide IP addresses or IP ranges for RealmJoin, and IP-based filtering is not supported.**
 {% endhint %}
 
 ### Azure Front Door
 
-RealmJoin services are delivered through [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview), Microsoft's global edge and CDN platform. This has direct consequences for network filtering:
+RealmJoin services — including the package CDN — are delivered through [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview), Microsoft's global edge and CDN platform. This has direct consequences for network filtering:
 
-* **No fixed IP ranges**: Azure Front Door uses a Microsoft-managed, global anycast IP pool. Microsoft can add, remove, or reassign these IP addresses at any time without notice.
-* **Do not allowlist IP addresses** for RealmJoin endpoints. IP-based rules will break without warning when Microsoft changes the Front Door infrastructure.
-* **Use FQDN-based filtering** (hostnames listed above) in firewalls and proxies instead.
-* If your firewall supports **Azure service tags**, the `AzureFrontDoor.Frontend` service tag covers Front Door's edge ranges and is updated by Microsoft automatically. This is the only supported alternative to FQDN-based rules.
+* **There are no fixed IP ranges.** Azure Front Door uses a Microsoft-managed, global anycast IP pool. Microsoft can add, remove, or reassign these IP addresses at any time without notice. For this reason, no IP list for RealmJoin exists or can be provided — any such list would be immediately outdated.
+* **IP-based allowlisting is not supported** and will break without warning when Microsoft changes the Front Door infrastructure. The same applies to DNS-level interception or rewriting of these hostnames.
+* **FQDN-based filtering** of the hostnames listed above is the only supported way to restrict RealmJoin traffic.
 
 ### Avoid Proxies
 


### PR DESCRIPTION
## Summary

Reworks the [Infrastructure Considerations](https://docs.realmjoin.com/deployment/infrastructure) page per c4a8/c4a8-issues-products-realmjoin-internal#298: keep all content, restructure for clarity, minimal prose.

### Changes

- **Connection endpoints as a table** with a purpose column per host; endpoints moved to the top of the page as the primary reference. The `#realmjoin-connection-endpoints` anchor is preserved (linked from the Chocolatey troubleshooting page).
- **Removed** `realmjoin-backend.azurewebsites.net` and `realmjoin-backend-staging.azurewebsites.net` as requested.
- **New Azure Front Door section**: RealmJoin services are delivered via Front Door, which has no fixed IP ranges — Microsoft manages its anycast IP pool and can change it at any time. Guidance: filter by FQDN, never by IP; `AzureFrontDoor.Frontend` service tag as the only supported alternative. A warning hint under the endpoint table points here.
- **Proxy section condensed** into bullets; the Azure/Office 365 IP-range download links, the weekly-update guidance, and the dynamic-IP caveat hint are all preserved.
- **BranchCache section restructured** into Configuration / Network requirements / How it works with bullets and a numbered flow — all existing facts (Delivery Optimization rationale, per-tenant CDN opt-out, `BranchCache.Mode`/`Disable-BC`, Distributed vs. Hosted Cache Mode, peer discovery) retained.

No content was removed beyond the two explicitly retired hostnames.

## Related

Closes c4a8/c4a8-issues-products-realmjoin-internal#298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6ViEuZFbUBLYRpg3Vvr54)_