### PR TITLE
Email Branding Enhancements

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -314,6 +314,7 @@
   * [Authentication](dev-reference/realmjoin-api/authentication.md)
 * [Report Functions](dev-reference/report-functions/README.md)
   * [Send-RjRbReportEmail](dev-reference/report-functions/send-rjrbreportemail.md)
+  * [Get-RjRbBrandingMailParams](dev-reference/report-functions/get-rjrbbrandingmailparams.md)
   * [Publish-RjRbFilesToStorageContainer](dev-reference/report-functions/publish-rjrbfilestostoragecontainer.md)
   * [Export-RjRbXlsx](dev-reference/report-functions/export-rjrbxlsx.md)
 * [Interacting with Runbooks](dev-reference/interacting-with-runbooks.md)

--- a/docs/automation/runbooks/runbook-report-settings.md
+++ b/docs/automation/runbooks/runbook-report-settings.md
@@ -73,6 +73,45 @@ All parameters are optional. If configured, they will appear in the email footer
 
 > **Note:** Some runbooks additionally accept a per-run ticket link (e.g. `ServiceDeskTicketUrl`) to reference the specific ticket that triggered the request. This is a runbook parameter, not part of this central configuration.
 
+### Email Branding (optional)
+
+Report emails can carry tenant-specific branding: the default RealmJoin header and footer graphics can be replaced with your own images, and the footer image can link to a custom target — for example your intranet or IT portal.
+
+To configure branding, add a `Branding` sub-section to the `RJReport` block (nested like `StorageAccount`):
+
+```json
+{
+    "Settings": {
+        "RJReport": {
+            "Branding": {
+                "HeaderImageUrl": "https://cdn.contoso.com/branding/email-header.png",
+                "FooterImageUrl": "https://cdn.contoso.com/branding/email-footer.png",
+                "FooterLink": "https://intranet.contoso.com"
+            }
+        }
+    }
+}
+```
+
+**Parameters:**
+
+| Setting | Required | Default | Description |
+| --- | --- | --- | --- |
+| `HeaderImageUrl` | no | RealmJoin header graphic | Public HTTPS URL of a custom header image that replaces the default RealmJoin header graphic |
+| `FooterImageUrl` | no | RealmJoin footer graphic | Public HTTPS URL of a custom footer image that replaces the default RealmJoin footer graphic |
+| `FooterLink` | no | `https://www.realmjoin.com` | URL the footer image links to |
+
+**Image requirements:**
+
+- The image must be reachable via a **public HTTPS URL** — for example an Azure Blob Storage container with anonymous read access, a CDN, or the company website.
+- Supported formats: **PNG, JPEG or GIF**.
+- Images are rendered at **750 px width**. Recommended dimensions are **750×200 px** (matching the default banners) or **1500×400 px** for high-DPI displays.
+- Maximum **200 KB** per image; **100 KB or less** is recommended. The branding images share the ~4 MB total email size limit with the report attachments (for comparison, the default RealmJoin graphics are 52 KB and 15 KB).
+
+The images are downloaded and validated by the runbook on each run. If a setting is left empty, the default RealmJoin graphic (and the default footer link) is used. If a download or validation fails, a warning is logged and the default graphic is used instead — a broken branding configuration never prevents a report email from being sent.
+
+All settings are optional and take effect for all runbooks that send report emails.
+
 ## Storage Account Delivery
 
 Reporting runbooks that support this delivery channel can upload their output to an Azure Blob Storage container. After a successful upload, the runbook returns a time-limited SAS link that can be used to download the file directly. This channel can be used independently of or in addition to email delivery.
@@ -92,9 +131,7 @@ Navigate to [RealmJoin Runbook Customization](https://portal.realmjoin.com/setti
             "StorageAccount": {
                 "ResourceGroup": "rg-reports",
                 "StorageAccountName": "stcontosoreports",
-                "LinkExpiryDays": 6,
-                "AddBlobNamePrefix": true,
-                "UseRandomPrefix": false
+                "LinkExpiryDays": 6
             }
         }
     }
@@ -108,10 +145,8 @@ Navigate to [RealmJoin Runbook Customization](https://portal.realmjoin.com/setti
 | `ResourceGroup` | yes | — | Resource group that contains the Storage Account |
 | `StorageAccountName` | yes | — | Name of the Azure Storage Account |
 | `LinkExpiryDays` | no | `6` | Number of days until the generated SAS download link expires |
-| `AddBlobNamePrefix` | no | `true` | Prepends a timestamp (`yyyyMMdd-HHmmss`) to the blob name to prevent overwrites |
-| `UseRandomPrefix` | no | `false` | Uses a 6-character alphanumeric random string as prefix instead of a timestamp; only applies when `AddBlobNamePrefix` is `true` |
 
-> **Note:** Settings that are specific to an individual runbook — such as the target container name or a custom blob name — are configured directly on that runbook and are intentionally not part of this central configuration.
+> **Note:** Settings that are specific to an individual runbook — such as the target container name or a custom blob name — are configured directly on that runbook and are intentionally not part of this central configuration. The same applies to blob-name prefixing: whether a timestamp prefix (`yyyyMMdd-HHmmss`) is prepended to the blob name to prevent overwrites is controlled by the `AddBlobNamePrefix` parameter of [`Publish-RjRbFilesToStorageContainer`](../../dev-reference/report-functions/publish-rjrbfilestostoragecontainer.md) (default `$false`), which each runbook passes explicitly.
 
 ## Combined Example
 
@@ -126,12 +161,15 @@ The following snippet shows a complete `RJReport` configuration with all feature
             "ServiceDesk_EMail": "servicedesk@domain.com",
             "ServiceDesk_Phone": "+49123456789",
             "ServiceDesk_PortalUrl": "https://servicedesk.domain.com",
+            "Branding": {
+                "HeaderImageUrl": "https://cdn.contoso.com/branding/email-header.png",
+                "FooterImageUrl": "https://cdn.contoso.com/branding/email-footer.png",
+                "FooterLink": "https://intranet.contoso.com"
+            },
             "StorageAccount": {
                 "ResourceGroup": "rg-reports",
                 "StorageAccountName": "stcontosoreports",
-                "LinkExpiryDays": 6,
-                "AddBlobNamePrefix": true,
-                "UseRandomPrefix": false
+                "LinkExpiryDays": 6
             }
         }
     }

--- a/docs/automation/runbooks/runbook-report-settings.md
+++ b/docs/automation/runbooks/runbook-report-settings.md
@@ -75,7 +75,7 @@ All parameters are optional. If configured, they will appear in the email footer
 
 ### Email Branding (optional)
 
-Report emails can carry tenant-specific branding: the default RealmJoin header and footer graphics can be replaced with your own images, and the footer image can link to a custom target — for example your intranet or IT portal.
+Report emails can carry tenant-specific branding: the default RealmJoin header and footer graphics can be replaced with your own images, the footer image can link to a custom target — for example your intranet or IT portal — and the template colors can be adjusted to your corporate design.
 
 To configure branding, add a `Branding` sub-section to the `RJReport` block (nested like `StorageAccount`):
 
@@ -86,7 +86,9 @@ To configure branding, add a `Branding` sub-section to the `RJReport` block (nes
             "Branding": {
                 "HeaderImageUrl": "https://cdn.contoso.com/branding/email-header.png",
                 "FooterImageUrl": "https://cdn.contoso.com/branding/email-footer.png",
-                "FooterLink": "https://intranet.contoso.com"
+                "FooterLink": "https://intranet.contoso.com",
+                "AccentColor": "#0052cc",
+                "TextColor": "#1a1a2e"
             }
         }
     }
@@ -100,17 +102,27 @@ To configure branding, add a `Branding` sub-section to the `RJReport` block (nes
 | `HeaderImageUrl` | no | RealmJoin header graphic | Public HTTPS URL of a custom header image that replaces the default RealmJoin header graphic |
 | `FooterImageUrl` | no | RealmJoin footer graphic | Public HTTPS URL of a custom footer image that replaces the default RealmJoin footer graphic |
 | `FooterLink` | no | `https://www.realmjoin.com` | URL the footer image links to |
+| `AccentColor` | no | `#f8842c` (RealmJoin orange) | Accent color of the email template: table header rows, action buttons, accent borders of the info boxes |
+| `TextColor` | no | `#011e33` (RealmJoin navy) | Primary text color of the email template: body text, headings, list items, code |
 
 **Image requirements:**
 
-- The image must be reachable via a **public HTTPS URL** — for example an Azure Blob Storage container with anonymous read access, a CDN, or the company website.
-- Supported formats: **PNG, JPEG or GIF**.
+- The image must be reachable via a **public HTTPS URL** — for example an Azure Blob Storage container with anonymous read access, a CDN, or the company website. A URL containing a SAS token also works and keeps the container private.
+- Supported formats: **PNG, JPEG or GIF**. The format is detected from the file signature, not from the file extension.
 - Images are rendered at **750 px width**. Recommended dimensions are **750×200 px** (matching the default banners) or **1500×400 px** for high-DPI displays.
 - Maximum **200 KB** per image; **100 KB or less** is recommended. The branding images share the ~4 MB total email size limit with the report attachments (for comparison, the default RealmJoin graphics are 52 KB and 15 KB).
 
-The images are downloaded and validated by the runbook on each run. If a setting is left empty, the default RealmJoin graphic (and the default footer link) is used. If a download or validation fails, a warning is logged and the default graphic is used instead — a broken branding configuration never prevents a report email from being sent.
+**Color requirements:**
+
+- Values must be 6-digit hexadecimal colors including the leading `#` — for example `#0052cc`. Short forms (`#05c`) and color names (`red`) are not supported.
+- Both emails and their attachments are read in light **and** dark mode: pick a text color that stays legible on a white content card, and an accent color with enough contrast against white button text.
+- Status colors (green/red/amber for success, error and warning states) and the neutral grays are deliberately not configurable — they carry meaning that should not change per tenant.
+
+The images are downloaded and validated by the runbook on each run. If a setting is left empty, the default RealmJoin graphic, color and footer link are used. If a download fails, an image is invalid, or a color is not a valid hex value, a warning is logged and the corresponding default is used instead — a broken branding configuration never prevents a report email from being sent.
 
 All settings are optional and take effect for all runbooks that send report emails.
+
+> **Note:** The color settings require **RealmJoin.RunbookHelper 0.8.9** or later in the Automation Account. With older module versions the image settings still apply and the colors are ignored.
 
 ## Storage Account Delivery
 
@@ -164,7 +176,9 @@ The following snippet shows a complete `RJReport` configuration with all feature
             "Branding": {
                 "HeaderImageUrl": "https://cdn.contoso.com/branding/email-header.png",
                 "FooterImageUrl": "https://cdn.contoso.com/branding/email-footer.png",
-                "FooterLink": "https://intranet.contoso.com"
+                "FooterLink": "https://intranet.contoso.com",
+                "AccentColor": "#0052cc",
+                "TextColor": "#1a1a2e"
             },
             "StorageAccount": {
                 "ResourceGroup": "rg-reports",

--- a/docs/dev-reference/report-functions/README.md
+++ b/docs/dev-reference/report-functions/README.md
@@ -10,5 +10,6 @@ This section documents the shared PowerShell helper functions available to Realm
 | Function | Purpose |
 | --- | --- |
 | [Send-RjRbReportEmail](send-rjrbreportemail.md) | Sends branded HTML report emails via Microsoft Graph. Converts Markdown content to responsive HTML and delivers one email per recipient. |
+| [Get-RjRbBrandingMailParams](get-rjrbbrandingmailparams.md) | Resolves the `RJReport.Branding.*` tenant settings — downloads and validates custom header/footer images — into parameters for `Send-RjRbReportEmail`. |
 | [Publish-RjRbFilesToStorageContainer](publish-rjrbfilestostoragecontainer.md) | Uploads report files to Azure Blob Storage and returns time-limited SAS download links. |
-| [Export-RjRbXlsx](export-rjrbxlsx.md) | Exports objects to styled native Excel workbooks (.xlsx) without external module dependencies. Not yet part of the module — planned for the next release. |
+| [Export-RjRbXlsx](export-rjrbxlsx.md) | Exports objects to styled native Excel workbooks (.xlsx) without external module dependencies. |

--- a/docs/dev-reference/report-functions/export-rjrbxlsx.md
+++ b/docs/dev-reference/report-functions/export-rjrbxlsx.md
@@ -9,8 +9,12 @@ description: Export objects from Azure Automation runbooks to styled native Exce
 
 `Export-RjRbXlsx` is the standard helper for producing Excel report files (`.xlsx`) from RealmJoin reporting runbooks. It writes one or more tables of `PSCustomObject`s as a **native Excel workbook** using only .NET (`System.IO.Compression`) — no `ImportExcel`, no COM automation, no other external module is required in the Automation environment.
 
-{% hint style="warning" %}
-**Not yet part of RealmJoin.RunbookHelper.** `Export-RjRbXlsx` is not yet shipped with the **RealmJoin.RunbookHelper** module — it will be included with the **next module release**. Until then, the function is duplicated inline in the runbooks that use it and can be copied from there, for example from [sync-MFA-secure-users-to-group_scheduled.ps1](https://github.com/realmjoin/realmjoin-runbooks/blob/master/org/security/sync-MFA-secure-users-to-group_scheduled.ps1) (region *Function Definitions*).
+{% hint style="info" %}
+**Available from RealmJoin.RunbookHelper 0.8.8.** The function is exported by the module; the inline copies that earlier runbook versions carried have been removed. Runbooks using it declare the module version accordingly:
+
+```powershell
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.8" }
+```
 {% endhint %}
 
 Key characteristics:
@@ -206,4 +210,4 @@ The function returns nothing. It writes the workbook to `Path` and emits a verbo
 - [Send-RjRbReportEmail](send-rjrbreportemail.md) — deliver the generated workbook as a report email attachment.
 - [Publish-RjRbFilesToStorageContainer](publish-rjrbfilestostoragecontainer.md) — upload the workbook to Azure Blob Storage and return a time-limited download link.
 - [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md) — central configuration of the report delivery channels.
-- Example inline usage: [sync-MFA-secure-users-to-group_scheduled.ps1](https://github.com/realmjoin/realmjoin-runbooks/blob/master/org/security/sync-MFA-secure-users-to-group_scheduled.ps1) — the runbook currently carrying the function until it ships with the module.
+- Example usage in a production runbook: [sync-MFA-secure-users-to-group_scheduled.ps1](https://github.com/realmjoin/realmjoin-runbooks/blob/master/org/security/sync-MFA-secure-users-to-group_scheduled.ps1) — builds a multi-worksheet workbook with an "Info" cover sheet.

--- a/docs/dev-reference/report-functions/get-rjrbbrandingmailparams.md
+++ b/docs/dev-reference/report-functions/get-rjrbbrandingmailparams.md
@@ -1,0 +1,117 @@
+---
+type: Developer Reference
+description: Resolve the RJReport.Branding tenant settings into ready-to-use parameters for Send-RjRbReportEmail.
+---
+
+# Get-RjRbBrandingMailParams
+
+## Overview
+
+`Get-RjRbBrandingMailParams` bridges the gap between the central [Email Branding settings](../../automation/runbooks/runbook-report-settings.md#email-branding-optional) and [`Send-RjRbReportEmail`](send-rjrbreportemail.md): the settings hold **URLs**, the send function expects **local file paths**. This function downloads the configured images, validates them, and returns a hashtable that can be splatted directly into the send call.
+
+> **Available from RealmJoin.RunbookHelper 0.8.9.** Earlier runbook versions carried this logic as an inline helper of the same name; those copies can be deleted once the Automation Account runs 0.8.9 or later.
+
+Design rules:
+
+- **Never fails the report.** Any problem — empty setting, non-HTTPS URL, failed download, oversized file, invalid image, malformed color — results in a warning and the omission of that single key. The email is then rendered with the corresponding RealmJoin default.
+- **Returns only what resolved.** The returned hashtable contains just the keys that succeeded, so splatting it never overrides a default with an empty value.
+- **One download per run.** Call it once and reuse the result for every email the runbook sends — including inside loops that notify many users.
+
+## Quick Start
+
+```powershell
+$brandingMailParams = Get-RjRbBrandingMailParams `
+    -HeaderImageUrl $BrandingHeaderImageUrl `
+    -FooterImageUrl $BrandingFooterImageUrl `
+    -FooterLink     $BrandingFooterLink `
+    -AccentColor    $BrandingAccentColor `
+    -TextColor      $BrandingTextColor
+
+Send-RjRbReportEmail `
+    -EmailFrom       $EmailFrom `
+    -EmailTo         $EmailTo `
+    -Subject         $Subject `
+    -MarkdownContent $reportMd `
+    @brandingMailParams
+```
+
+With no branding configured, `$brandingMailParams` is an empty hashtable and the call behaves exactly as if the parameter had been omitted.
+
+## Parameters
+
+All parameters are optional — the function is designed to be called with whatever the tenant happens to have configured.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `HeaderImageUrl` | `string` | — | Public HTTPS URL of the header image (`RJReport.Branding.HeaderImageUrl`). |
+| `FooterImageUrl` | `string` | — | Public HTTPS URL of the footer image (`RJReport.Branding.FooterImageUrl`). |
+| `FooterLink` | `string` | — | Target URL of the footer image (`RJReport.Branding.FooterLink`). Passed through, not validated. |
+| `AccentColor` | `string` | — | Accent color (`RJReport.Branding.AccentColor`). Passed through; the hex format is validated by `Send-RjRbReportEmail`. |
+| `TextColor` | `string` | — | Text color (`RJReport.Branding.TextColor`). Same handling as `AccentColor`. |
+| `TimeoutSec` | `int` | `30` | Download timeout per image. |
+| `MaxImageBytes` | `long` | `200KB` | Maximum accepted image size. Branding images share the ~4 MB `sendMail` limit with the report attachments. |
+
+## Outputs
+
+A `[hashtable]` containing only the successfully resolved keys:
+
+| Key | Value |
+| --- | --- |
+| `HeaderImage` | Local path of the downloaded header image |
+| `FooterImage` | Local path of the downloaded footer image |
+| `FooterLink` | Trimmed footer link |
+| `AccentColor` | Trimmed accent color |
+| `TextColor` | Trimmed text color |
+
+Every key maps to a parameter of `Send-RjRbReportEmail`, which is what makes splatting safe.
+
+## Validation
+
+Each image passes through the following checks before it is accepted:
+
+| Check | Rejection reason |
+| --- | --- |
+| URL scheme | Only `https` is accepted — the image bytes end up inside company mail, so plain HTTP is refused. |
+| Download | Non-2xx responses, timeouts and network errors are caught; the response body of a storage error is not silently treated as an image. |
+| Size | Empty files and files larger than `MaxImageBytes` (default 200 KB). |
+| File signature | The first bytes must identify a PNG, JPEG or GIF. An HTML error page saved under a `.png` name is rejected here. |
+
+The temp file is given the extension matching its **detected** format, because `Send-RjRbReportEmail` derives the attachment content type from it — a URL without a file extension, or with a misleading one, therefore works correctly.
+
+## Behavior Notes
+
+### Hosting the images
+
+The URL only needs to be reachable from the Azure Automation sandbox. Two common patterns:
+
+- **Public blob or CDN** — simplest, but the images are readable by anyone.
+- **Private container with a SAS token in the URL** — the container stays private and only holders of the link can read it. Remember that the SAS expiry silently ends branding: after it lapses, reports continue to arrive with the RealmJoin defaults and the reason is only visible as a warning in the job log.
+
+### Temp file cleanup
+
+Downloaded images are written to the sandbox temp directory. The sandbox is discarded after the run, so cleanup is optional — but runbooks with an explicit cleanup region should remove them after the last email:
+
+```powershell
+foreach ($brandingKey in @('HeaderImage', 'FooterImage')) {
+    if ($brandingMailParams -and $brandingMailParams.ContainsKey($brandingKey) -and (Test-Path -LiteralPath $brandingMailParams[$brandingKey])) {
+        Remove-Item -LiteralPath $brandingMailParams[$brandingKey] -Force -ErrorAction SilentlyContinue
+    }
+}
+```
+
+### Diagnosing branding that does not appear
+
+When a report arrives with the default graphics although branding is configured, the job log identifies the stage that failed:
+
+| Log entry | Cause |
+| --- | --- |
+| No `Branding:` entry at all | The settings never reached the runbook — check the customization JSON and whether the portal knows this runbook version. |
+| `Only HTTPS URLs are supported` | The URL uses `http://`. |
+| A storage error such as `PublicAccessNotPermitted` | The request arrived unauthenticated — the SAS token is missing from the URL, often because it was truncated when copied. |
+| `exceeds the … limit for inline email images` | The file is larger than `MaxImageBytes`. |
+| `not a PNG, JPEG or GIF image` | The download returned something other than an image, typically an error page. |
+
+## See Also
+
+- [Send-RjRbReportEmail](send-rjrbreportemail.md) — the consumer of the returned parameters.
+- [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md#email-branding-optional) — configuring the `RJReport.Branding.*` settings as an administrator.

--- a/docs/dev-reference/report-functions/publish-rjrbfilestostoragecontainer.md
+++ b/docs/dev-reference/report-functions/publish-rjrbfilestostoragecontainer.md
@@ -84,15 +84,15 @@ This uploads `devices.csv` to the `reports` container in `stcontosoreports` and 
 | --- | --- | --- |
 | `FilePaths` | `string[]` | One or more local file paths to upload. Each path must point to an existing file (`Test-Path -PathType Leaf`); the function throws upfront if any entry is missing. |
 | `ContainerName` | `string` | Target blob container. Created automatically if it does not exist. Must comply with Azure container naming rules (lowercase, 3–63 chars, alphanumeric + hyphen). Container name is a *per-runbook* decision and is set in the runbook, not in central settings. |
-| `ResourceGroupName` | `string` | Resource group that contains the storage account. Usually wired to the central setting `RJReport.AzureStorage.ResourceGroup`. |
-| `StorageAccountName` | `string` | Name of the Azure Storage Account. Usually wired to the central setting `RJReport.AzureStorage.StorageAccountName`. |
+| `ResourceGroupName` | `string` | Resource group that contains the storage account. Usually wired to the central setting `RJReport.StorageAccount.ResourceGroup`. |
+| `StorageAccountName` | `string` | Name of the Azure Storage Account. Usually wired to the central setting `RJReport.StorageAccount.StorageAccountName`. |
 
 ### Optional
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | `SubscriptionId` | `string` | current context | Azure subscription that hosts the storage account. If supplied, `Set-AzContext -Subscription` is called before any storage operation. Omit to use the current `Az` context. |
-| `LinkExpiryDays` | `int` | `6` | SAS link validity in days. Validated to `[1, 3650]`. The same expiry timestamp is applied to all blobs in a single call. Usually wired to the central setting `RJReport.AzureStorage.LinkExpiryDays`. |
+| `LinkExpiryDays` | `int` | `6` | SAS link validity in days. Validated to `[1, 3650]`. The same expiry timestamp is applied to all blobs in a single call. Usually wired to the central setting `RJReport.StorageAccount.LinkExpiryDays`. |
 | `AddBlobNamePrefix` | `bool` | `$false` | When `$true`, blob names are prefixed with `yyyyMMdd-HHmmss-` (timestamp from `Get-Date` at upload time) to prevent overwrites in repeated runs. The original file name is kept as the suffix. |
 
 > **Note:** The mapping between these parameters and the central RealmJoin customization JSON (including the recommended defaults) is documented in [Runbook Report Settings — Storage Account Delivery](../../automation/runbooks/runbook-report-settings.md#storage-account-delivery).
@@ -110,13 +110,13 @@ This is the canonical pattern used by reporting runbooks. Storage configuration 
 param(
     [string] $ContainerName = "my-runbook-output",
 
-    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.AzureStorage.ResourceGroup" } )]
+    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.StorageAccount.ResourceGroup" } )]
     [string] $ResourceGroupName,
 
-    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.AzureStorage.StorageAccountName" } )]
+    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.StorageAccount.StorageAccountName" } )]
     [string] $StorageAccountName,
 
-    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.AzureStorage.LinkExpiryDays" } )]
+    [ValidateScript( { Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Use-RJInterface -Type Setting -Attribute "RJReport.StorageAccount.LinkExpiryDays" } )]
     [ValidateRange(1, 3650)]
     [int] $LinkExpiryDays = 6
 )
@@ -126,8 +126,8 @@ Connect-RjRbAzAccount
 if ((-not $ResourceGroupName) -or (-not $StorageAccountName)) {
     "## To export to a storage account, please use RJ Runbooks Customization"
     "## ( https://portal.realmjoin.com/settings/runbooks-customizations ) to configure:"
-    "##   - RJReport.AzureStorage.ResourceGroup"
-    "##   - RJReport.AzureStorage.StorageAccountName"
+    "##   - RJReport.StorageAccount.ResourceGroup"
+    "##   - RJReport.StorageAccount.StorageAccountName"
     throw "Missing Storage Account Configuration."
 }
 
@@ -246,7 +246,7 @@ Each file is uploaded via `HttpClient.SendAsync`. A non-success status terminate
 - Missing `Microsoft.Storage/storageAccounts/listKeys/action` on the managed identity.
 - Wrong subscription context (combine with `-SubscriptionId`).
 - Typo in `StorageAccountName` or `ResourceGroupName`.
-- The central settings `RJReport.AzureStorage.ResourceGroup` / `RJReport.AzureStorage.StorageAccountName` not configured — see [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md#storage-account-delivery).
+- The central settings `RJReport.StorageAccount.ResourceGroup` / `RJReport.StorageAccount.StorageAccountName` not configured — see [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md#storage-account-delivery).
 
 ### SAS token characteristics
 

--- a/docs/dev-reference/report-functions/send-rjrbreportemail.md
+++ b/docs/dev-reference/report-functions/send-rjrbreportemail.md
@@ -16,8 +16,10 @@ Key characteristics:
 - **Markdown in, HTML out** — runbooks compose the report body in Markdown; the function renders it to themed HTML that works across Outlook Classic, New Outlook, Outlook Web, mobile clients and dark mode.
 - **One email per recipient** — when multiple recipients are supplied, the function sends an individual message to each address rather than a single multi-recipient mail. This is a privacy/BCC-by-default design.
 - **Inline branded header & footer** — bundled PNG assets are sent as CID attachments and referenced by the embedded HTML. Both can be overridden or suppressed entirely.
+- **Customizable template colors** — the accent and text color of the template can be overridden per call, so report emails can follow a customer's corporate design.
+- **Built-in attachment size guard** — an optional smaller fallback attachment set is sent automatically when the regular set exceeds the size budget or its send attempt fails.
 - **Self-connecting** — if no Graph session is active, the function transparently calls `Connect-RjRbGraph` (or `Connect-MgGraph -Identity` when `-UseNativeGraphRequest` is set).
-- **Resilient** — failed attachment reads, missing image overrides, or per-recipient sendMail failures are reported but do not abort the entire batch unless *all* recipients fail.
+- **Resilient** — failed attachment reads, invalid image overrides, invalid colors, or per-recipient sendMail failures are reported but do not abort the entire batch unless *all* recipients fail.
 
 Centralized email settings (sender address, service desk info) are documented in [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md) — this document focuses on calling the function from a runbook.
 
@@ -90,8 +92,27 @@ This produces a fully branded RealmJoin email with the default header and footer
 | `FooterLink` | `string` | `https://www.realmjoin.com` | URL used as the `href` and `title` of the anchor wrapping the footer image. |
 | `NoHeader` | `switch` | off | Suppresses the header graphic entirely. If combined with `HeaderImage`, a warning is emitted and the override is ignored. |
 | `NoFooter` | `switch` | off | Suppresses the footer graphic and its link entirely. If combined with `FooterImage` or a custom `FooterLink`, a warning is emitted and those values are ignored. |
+| `AccentColor` | `string` | `#f8842c` | *New in 0.8.9.* 6-digit hex color for table header rows, action buttons and the accent borders of the info boxes. An empty or malformed value emits a warning and falls back to the default. |
+| `TextColor` | `string` | `#011e33` | *New in 0.8.9.* 6-digit hex color for body text, headings, list items and code. Same fallback behavior as `AccentColor`. |
 
 **Recommended image dimensions:** 750 × 200 px PNG. This matches the email container width and the bundled defaults. Significantly different aspect ratios may look distorted on narrow viewports. Each graphic should stay well below 3 MB — Graph caps the total `sendMail` request at 4 MB and a warning is emitted if either image exceeds 3 MB.
+
+**Colors:** without `AccentColor`/`TextColor` the generated HTML is byte-for-byte identical to previous module versions — the defaults are the RealmJoin orange and navy. Status colors (green/red/amber) and neutral grays are intentionally not parameterized because they convey meaning. Verify custom colors in both light and dark mode: the content card stays white in dark mode, so a very light text color becomes unreadable.
+
+### Optional — Attachment size guard
+
+*New in 0.8.9.* Graph rejects the whole `sendMail` request once the message exceeds ~4 MB. Instead of failing the report, the function can fall back to a smaller attachment set. This logic was previously duplicated as the inline runbook helper `Send-RjRbGuardedReportEmail` and is now part of the function itself.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `FallbackAttachments` | `string[]` | — | Smaller attachment set used when the regular set exceeds `MaxAttachmentBytes`, or when the send with the regular set fails for every recipient. Without this parameter there is no fallback and a failed send throws immediately. |
+| `FallbackMarkdownContent` | `string` | value of `MarkdownContent` | Body used when the fallback set is sent — use it to explain which files were left out and how to obtain them. |
+| `MaxAttachmentBytes` | `long` | `2.5MB` | Raw size budget for the regular attachment set. Stays safely below the ~4 MB Graph limit after base64 encoding (+33 %), HTML body and inline branding images. Only evaluated when `FallbackAttachments` is supplied. |
+
+The guard runs in two stages:
+
+1. **Before sending** — if the regular set exceeds the budget, the fallback set is sent directly and a message names both sizes.
+2. **After a failed send** — if the send with the regular set fails for *all* recipients, one retry with the fallback set is attempted before the function throws.
 
 ### Optional — Transport
 
@@ -154,6 +175,41 @@ Send-RjRbReportEmail `
 ```
 
 If `$headerPath` is missing or unreadable, the call still succeeds — the bundled RealmJoin default is used and a warning is logged.
+
+### Custom template colors
+
+Match the email to a customer's corporate design. Both parameters are independent — overriding only the accent color keeps the default text color:
+
+```powershell
+Send-RjRbReportEmail `
+    -EmailFrom       "realmjoin-report@contoso.com" `
+    -EmailTo         "alice@contoso.com" `
+    -Subject         "Branded Report" `
+    -MarkdownContent $reportMd `
+    -AccentColor     "#0052cc" `
+    -TextColor       "#1a1a2e"
+```
+
+An invalid value (for example `blue` or `#05c`) does not fail the send: a warning names the parameter and the default color is used.
+
+### Large reports with a fallback attachment set
+
+Generate a CSV and an Excel workbook, but fall back to the workbook alone when the pair exceeds the size budget:
+
+```powershell
+$sizeHint = "The CSV export was omitted because the attachments exceeded the email size limit. The Excel workbook contains the complete data."
+
+Send-RjRbReportEmail `
+    -EmailFrom                "realmjoin-report@contoso.com" `
+    -EmailTo                  "it-reports@contoso.com" `
+    -Subject                  "Device Inventory" `
+    -MarkdownContent          $reportMd `
+    -Attachments              @($csvPath, $xlsxPath) `
+    -FallbackAttachments      @($xlsxPath) `
+    -FallbackMarkdownContent  ($reportMd + "`n`n> **Note:** $sizeHint")
+```
+
+Runbooks migrating from the inline helper `Send-RjRbGuardedReportEmail` can drop that function and rename the call to `Send-RjRbReportEmail` — the parameter names (`Attachments`, `FallbackAttachments`, `FallbackMarkdownContent`, `MaxAttachmentBytes`) are unchanged.
 
 ### Plain content (no header/footer)
 
@@ -265,36 +321,76 @@ Each recipient is sent independently. The function tracks successes and failures
 
 ### Image override failures
 
-Both `HeaderImage` and `FooterImage` fall back to the bundled defaults on any error (missing file, unsupported extension, IO error). A warning describes the failure and identifies which default was used.
+Both `HeaderImage` and `FooterImage` fall back to the bundled defaults on any error (missing file, IO error, or a file that is not a valid image). A warning describes the failure and identifies which default was used.
+
+Since 0.8.9 the image format is determined from the **file signature** (magic bytes) rather than the file extension. A file that is named `.png` but actually contains an HTML error page — a common outcome when a download silently returns an error document — is now rejected with a warning instead of producing a broken inline attachment. Conversely, a valid PNG saved under a misleading extension is accepted and typed correctly.
+
+### Invalid colors
+
+`AccentColor` and `TextColor` are validated against `^#[0-9A-Fa-f]{6}$`. A value that does not match emits a warning naming the parameter and the send proceeds with the default color. Colors are never a reason for a report to fail.
 
 ### Total size limit
 
-Graph caps `sendMail` requests at ~4 MB combined (HTML body + all attachments, base64-encoded). The function emits a warning when either branding image exceeds 3 MB. If the total payload still exceeds 4 MB the Graph call itself will fail; consider:
+Graph caps `sendMail` requests at ~4 MB combined (HTML body + all attachments, base64-encoded). The function emits a warning when either branding image exceeds 3 MB.
 
+When `FallbackAttachments` is supplied, the attachment size guard described in the parameter section above handles oversized payloads automatically. Without a fallback set, an oversized request fails in the Graph call; consider:
+
+- Supplying a `FallbackAttachments` set (for example the Excel workbook without the raw CSV files).
 - Uploading large data to the Storage Account channel instead — see [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md#storage-account-delivery).
 - Linking to externally hosted attachments rather than embedding them.
 - Compressing tabular data (`Compress-Archive`) before attaching.
 
 ## Integration with Runbook Report Settings
 
-Reporting runbooks typically resolve the sender address from the central RealmJoin customization JSON rather than hard-coding it. The relevant settings are documented in [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md). A typical resolution pattern in a runbook looks like:
+Reporting runbooks do not hard-code the sender address or branding: they declare hidden parameters that the RealmJoin portal prefills from the central customization JSON. The available settings are documented in [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md).
+
+The binding happens in the runbook's `param()` block via `Use-RJInterface -Type Setting`, and the parameters are marked `"Hide": true` in the `.INPUTS RunbookCustomization` block so they do not clutter the portal form:
 
 ```powershell
-# Read centralized settings (resolved by the runbook framework)
-$emailFrom = (Get-RjRbDefaultValue -Name 'EmailSender' -Section 'RJReport')
+param(
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.EmailSender" -Value $_ } )]
+    [string]$EmailFrom,
 
-if (-not $emailFrom) {
-    throw "No EmailSender configured. See https://docs.realmjoin.com/ for setup instructions."
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.Branding.HeaderImageUrl" -Value $_ } )]
+    [string]$BrandingHeaderImageUrl,
+
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.Branding.FooterImageUrl" -Value $_ } )]
+    [string]$BrandingFooterImageUrl,
+
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.Branding.FooterLink" -Value $_ } )]
+    [string]$BrandingFooterLink,
+
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.Branding.AccentColor" -Value $_ } )]
+    [string]$BrandingAccentColor,
+
+    [ValidateScript( { Use-RJInterface -Type Setting -Attribute "RJReport.Branding.TextColor" -Value $_ } )]
+    [string]$BrandingTextColor
+)
+
+if (-not $EmailFrom) {
+    throw "No EmailSender configured. See https://docs.realmjoin.com/automation/runbooks/runbook-report-settings for setup instructions."
 }
 
+# Download and validate the branding images once per run; returns only the keys
+# that resolved successfully, so unset settings fall through to the defaults.
+$brandingMailParams = Get-RjRbBrandingMailParams `
+    -HeaderImageUrl $BrandingHeaderImageUrl `
+    -FooterImageUrl $BrandingFooterImageUrl `
+    -FooterLink     $BrandingFooterLink `
+    -AccentColor    $BrandingAccentColor `
+    -TextColor      $BrandingTextColor
+
 Send-RjRbReportEmail `
-    -EmailFrom       $emailFrom `
-    -EmailTo         $RecipientParameter `
-    -Subject         $Subject `
-    -MarkdownContent $reportMd `
+    -EmailFrom         $EmailFrom `
+    -EmailTo           $RecipientParameter `
+    -Subject           $Subject `
+    -MarkdownContent   $reportMd `
     -TenantDisplayName $TenantDisplayName `
-    -ReportVersion     "MyReport v1.0"
+    -ReportVersion     "MyReport v1.0" `
+    @brandingMailParams
 ```
+
+See [Get-RjRbBrandingMailParams](get-rjrbbrandingmailparams.md) for the download, validation and cleanup rules.
 
 ## Outputs
 
@@ -306,13 +402,15 @@ The building blocks behind `Send-RjRbReportEmail` are now exported from the modu
 
 | Function | Purpose |
 | --- | --- |
-| `ConvertFrom-RjRbMarkdownToHtml` | Standalone Markdown → HTML converter (the same lightweight engine used internally, including the `{button}` syntax). |
-| `Get-RjRbReportEmailBody` | Assembles the full branded HTML body (header/footer, tenant-info box, attachment list) from HTML or Markdown — useful to render and inspect the email before sending. |
-| `Resolve-RjRbImageSource` | Resolves a header/footer image path to its inline CID source, falling back to the bundled default on error. |
+| [`Get-RjRbBrandingMailParams`](get-rjrbbrandingmailparams.md) | Turns the `RJReport.Branding.*` tenant settings into ready-to-splat parameters: downloads and validates the images, passes colors and footer link through. |
+| `ConvertFrom-RjRbMarkdownToHtml` | Standalone Markdown → HTML converter (the same lightweight engine used internally, including the `{button}` syntax). Accepts `-AccentColor`/`-TextColor`. |
+| `Get-RjRbReportEmailBody` | Assembles the full branded HTML body (header/footer, tenant-info box, attachment list) from HTML or Markdown — useful to render and inspect the email before sending. Accepts `-AccentColor`/`-TextColor`. |
+| `Resolve-RjRbImageSource` | Resolves a header/footer image path to its inline CID source. Validates by file signature and throws on anything that is not a PNG, JPEG or GIF. |
 
-These are primarily intended for advanced/testing scenarios; the normal path is to call `Send-RjRbReportEmail` directly.
+Except for `Get-RjRbBrandingMailParams`, these are primarily intended for advanced/testing scenarios; the normal path is to call `Send-RjRbReportEmail` directly.
 
 ## See Also
 
-- [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md) — central configuration of the sender mailbox, service desk info, and Storage Account delivery channel.
+- [Get-RjRbBrandingMailParams](get-rjrbbrandingmailparams.md) — resolving the tenant branding settings inside a runbook.
+- [Runbook Report Settings](../../automation/runbooks/runbook-report-settings.md) — central configuration of the sender mailbox, service desk info, branding, and Storage Account delivery channel.
 - Microsoft Graph: [Send mail](https://learn.microsoft.com/en-us/graph/api/user-sendmail) — underlying API.


### PR DESCRIPTION
This pull request updates the documentation for RealmJoin runbook reporting, focusing on improved support and documentation for tenant-specific email branding and clarifying the configuration of storage account delivery. It also introduces and documents the new `Get-RjRbBrandingMailParams` helper, updates the status of `Export-RjRbXlsx` as part of the module, and standardizes configuration key names for storage account settings.

**Email Branding Enhancements:**

* Added a comprehensive section to `runbook-report-settings.md` documenting how to configure tenant-specific email branding for report emails, including image and color customization, requirements, and fallback behavior.
* Provided a detailed example of branding configuration in the combined settings JSON, and updated parameter tables to reflect these changes.
* Added a new reference entry for the `Get-RjRbBrandingMailParams` function, which resolves branding settings and prepares them for use with `Send-RjRbReportEmail`.
* Updated the summary and function list to include `Get-RjRbBrandingMailParams`. [[1]](diffhunk://#diff-492f4fe6d732168c58e78f2a627614dc59f1e41a5d12da3d8347d3957e9673f6R317) [[2]](diffhunk://#diff-d9e45dbf9e72611644cbf1a3161252a83f1fba49d81cec36c425f9d918843336R13-R15)

**Storage Account Configuration Clarification:**

* Clarified that blob name prefixing is controlled per-runbook via the `AddBlobNamePrefix` parameter of `Publish-RjRbFilesToStorageContainer`, not via central configuration, and updated documentation and examples accordingly. [[1]](diffhunk://#diff-015f3e1b5ccb76af3750db7982e4f8340e20b4b182bb799a14899dd318932b99L95-R146) [[2]](diffhunk://#diff-015f3e1b5ccb76af3750db7982e4f8340e20b4b182bb799a14899dd318932b99L111-R161)
* Standardized configuration key names from `RJReport.AzureStorage.*` to `RJReport.StorageAccount.*` throughout the documentation and usage examples for consistency. [[1]](diffhunk://#diff-e1d4563df95735932b1208c07526031d0c769299702e6ef9c29c6cb6ea6f2439L87-R95) [[2]](diffhunk://#diff-e1d4563df95735932b1208c07526031d0c769299702e6ef9c29c6cb6ea6f2439L113-R119) [[3]](diffhunk://#diff-e1d4563df95735932b1208c07526031d0c769299702e6ef9c29c6cb6ea6f2439L129-R130)

**Module and Function Documentation Updates:**

* Updated the documentation for `Export-RjRbXlsx` to reflect that it is now officially included in the `RealmJoin.RunbookHelper` module as of version 0.8.8, removing references to inline copies. [[1]](diffhunk://#diff-a7db97955529cd34aeeef6bcbb1e281879f026210e3c8688853586ddaffd1585L12-R17) [[2]](diffhunk://#diff-a7db97955529cd34aeeef6bcbb1e281879f026210e3c8688853586ddaffd1585L209-R213)
* Updated the function list for report helpers to reflect the current state of module inclusion and purpose.