### PR TITLE
docs: rename Azure Marketplace to Microsoft Marketplace

### DIFF
--- a/docs/administration-and-settings/workplace-cloud-storage.md
+++ b/docs/administration-and-settings/workplace-cloud-storage.md
@@ -17,7 +17,7 @@ Currently the following types are supported:
 * Backgrounds and other files
 * Outlook signatures
 
-This native integration in RealmJoin makes the separate app (Azure Web App) from GitHub or Azure Marketplace obsolete: [M365 Workplace Cloud Storage](https://github.com/glueckkanja/gk-m365-workplacecloudstorage)
+This native integration in RealmJoin makes the separate app (Azure Web App) from GitHub or Microsoft Marketplace obsolete: [M365 Workplace Cloud Storage](https://github.com/glueckkanja/gk-m365-workplacecloudstorage)
 
 The feature of managing Enterprise Mode Site Lists is covered by Microsoft 365 admin center. So, existing or new site lists need to be added as described here: [Publish enterprise site list to the cloud](https://learn.microsoft.com/en-us/deployedge/edge-ie-mode-cloud-site-list-mgmt#publish-enterprise-site-list-to-the-cloud-1). The resulting site list ID is then published via an Intune policy to Microsoft Edge.
 
@@ -59,7 +59,7 @@ If so, please move to "Settings" of your storage account and set "Allow Blob ano
 
 ### Migration from Azure Web App
 
-If you are currently using the separate web app from [GitHub](https://github.com/glueckkanja/gk-m365-workplacecloudstorage) or Azure Marketplace, you can easily migrate to native RealmJoin integration.
+If you are currently using the separate web app from [GitHub](https://github.com/glueckkanja/gk-m365-workplacecloudstorage) or Microsoft Marketplace, you can easily migrate to native RealmJoin integration.
 
 {% hint style="warning" %}
 Please note that **managing Enterprise Mode Site Lists** is **not possible** via RealmJoin. Please **migrate** your lists to Microsoft 365 admin center **before the following steps** as describe in [Overview](workplace-cloud-storage.md#overview).

--- a/docs/legal/licensing/microsoft-marketplace.md
+++ b/docs/legal/licensing/microsoft-marketplace.md
@@ -1,7 +1,7 @@
 ---
 type: Legal
 description: >-
-  Purchase RealmJoin via Azure Marketplace: prerequisites, the user-segment
+  Purchase RealmJoin via Microsoft Marketplace: prerequisites, the user-segment
   pricing model, base fees, and invoicing.
 ---
 
@@ -18,7 +18,7 @@ In order to purchase solutions from independent software vendors (ISV) such as R
 ## How to purchase RealmJoin?
 
 {% hint style="info" %}
-Deploying a RealmJoin subscription via Azure Marketplace **will not result** **in a re-configuration of your RealmJoin tenant if you already have an active trial or production tenant**. Instead, we will assign the license obtained as part of this subscription to your existing tenant.
+Deploying a RealmJoin subscription via Microsoft Marketplace **will not result** **in a re-configuration of your RealmJoin tenant if you already have an active trial or production tenant**. Instead, we will assign the license obtained as part of this subscription to your existing tenant.
 
 For **new customers**, we will provision a new RealmJoin tenant once below steps are completed. **We will require our \*.onmicrosoft.com domain for this**. Please allow up to 1 business day for us to complete the provisioning.
 {% endhint %}
@@ -56,7 +56,7 @@ In case we have extended a **Private Offer** to you or your MSP/distribution has
 <figure><img src="../../.gitbook/assets/image (4).png" alt=""><figcaption></figcaption></figure>
 
 {% hint style="info" %}
-The random order of **Base Fees** und **Additional Users** under the **Price** information is attributed to limitations of the Azure Marketplace. Later during the the enrolment process, we will provide you with transparent information on the expected licensing fees.
+The random order of **Base Fees** und **Additional Users** under the **Price** information is attributed to limitations of the Microsoft Marketplace. Later during the the enrolment process, we will provide you with transparent information on the expected licensing fees.
 {% endhint %}
 {% endstep %}
 
@@ -121,10 +121,10 @@ For a more detailed cost breakdown of your base and additional user fees, please
 
 ## Plan Overview
 
-RealmJoin is available in two [editions](./#realmjoin-plans) via separate offers on Azure Marketplace.
+RealmJoin is available in two [editions](./#realmjoin-plans) via separate offers on Microsoft Marketplace.
 
-* [RealmJoin Apps](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/glueckkanja-gabag.realmjoin-apps-transactable-prod?tab=Overview)
-* [RealmJoin Enterprise](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/glueckkanja-gabag.realmjoin-enterprise-transactable-prod?tab=Overview)
+* [RealmJoin Apps](https://marketplace.microsoft.com/en-us/marketplace/apps/glueckkanja-gabag.realmjoin-apps-transactable-prod?tab=Overview)
+* [RealmJoin Enterprise](https://marketplace.microsoft.com/en-us/marketplace/apps/glueckkanja-gabag.realmjoin-enterprise-transactable-prod?tab=Overview)
 
 Subscriptions for both editions of RealmJoin are available based on a **monthly** or **annual** renewal interval.
 
@@ -191,12 +191,12 @@ In case you would like to test RealmJoin, simply [self-enrol your tenant via our
 
 ## FAQs
 
-### Why is my Azure Marketplace purchase not working?
+### Why is my Microsoft Marketplace purchase not working?
 
-You may encounter problems when purchasing through Azure Marketplace. Here is a list of reasons, why buying through Azure Marketplace may fail:
+You may encounter problems when purchasing through Microsoft Marketplace. Here is a list of reasons, why buying through Microsoft Marketplace may fail:
 
-1. You do not have permissions in your Azure tenant to purchase through Azure Marketplace. You must be assigned the role of Owner or Contributor in the Azure subscription you want to pay with.
-2. The subscription belongs to an Enterprise Agreement (EA) and the EA admin disabled Azure Marketplace purchases. Or the EA admin has enabled purchases only for free offers and the offer is a paid offer. Please see [here](https://learn.microsoft.com/en-us/marketplace/purchase-control-options) for details.
+1. You do not have permissions in your Azure tenant to purchase through Microsoft Marketplace. You must be assigned the role of Owner or Contributor in the Azure subscription you want to pay with.
+2. The subscription belongs to an Enterprise Agreement (EA) and the EA admin disabled Microsoft Marketplace purchases. Or the EA admin has enabled purchases only for free offers and the offer is a paid offer. Please see [here](https://learn.microsoft.com/en-us/marketplace/purchase-control-options) for details.
 3.  The subscription you're using belongs to a billing account in a region where the offer isn't available.\
     Our Marketplace offers are available in the following countries/regions:
 


### PR DESCRIPTION
Microsoft rebranded Azure Marketplace as **Microsoft Marketplace**. This updates the remaining user-facing occurrences in this repo.

## Changes

| File | What |
|---|---|
| `docs/legal/licensing/microsoft-marketplace.md` | 9× display text (incl. frontmatter `description`), 2× offer links moved to `marketplace.microsoft.com` |
| `docs/administration-and-settings/workplace-cloud-storage.md` | 2× display text |

## Deliberately unchanged

- `Microsoft_Azure_Marketplace` inside `portal.azure.com/#view/...` deep links — that is a technical Azure Portal blade identifier, not display text. Renaming it would break the links.
- Anchors like `#...-in-azure-marketplace` on `learn.microsoft.com` — anchors on pages we do not control.

## URLs

No page was renamed here, so no slug changes and no new redirects are needed. The earlier slug change (`legal/licensing/azure-marketplace` → `microsoft-marketplace`, commit a9635f5) is already covered by GitBooks automatic redirect — verified: the old URL answers `307` to the new one.

One caveat worth knowing: the heading `Why is my Azure Marketplace purchase not working?` changes its anchor to `#why-is-my-microsoft-marketplace-purchase-not-working`. Nothing in any of the four docs repos links to the old anchor, but external deep links to it would break — GitBook does not redirect anchors.

The offer links now point at `marketplace.microsoft.com`; `azuremarketplace.microsoft.com` currently `308`-redirects there, so both work — we just use the new domain directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)