### PR TITLE
docs: clarify Microsoft 365 group limitations for report email sender and recipients

### DIFF
--- a/docs/automation/runbooks/runbook-report-settings.md
+++ b/docs/automation/runbooks/runbook-report-settings.md
@@ -24,6 +24,8 @@ The functions that consume these settings — [`Send-RjRbReportEmail`](../../dev
 
 We recommend using a dedicated shared mailbox, such as `realmjoin-report@contoso.com`. This mailbox will be used as the sender address for all reports. You can use a no-reply address, as recipients are not expected to respond to automated reports.
 
+> **Note:** The sender address must be a user or shared mailbox — a Microsoft 365 group cannot send mail via the Graph API. Group addresses as report **recipients** work technically, but are not recommended: whether members actually receive the email depends on the group's follow/subscription settings, and delivery failures are only visible as non-delivery reports in the sender mailbox.
+
 ### Configuration
 
 As described in detail in the [JSON Based Customizing](https://docs.realmjoin.com/automation/runbooks/runbook-customization#json-based-customizing) documentation, navigate to [RealmJoin Runbook Customization](https://portal.realmjoin.com/settings/runbooks-customizations) in the RealmJoin Portal (Settings > Runbook Customizations).

--- a/docs/dev-reference/report-functions/send-rjrbreportemail.md
+++ b/docs/dev-reference/report-functions/send-rjrbreportemail.md
@@ -29,6 +29,10 @@ Centralized email settings (sender address, service desk info) are documented in
 
 A licensed Microsoft 365 mailbox (typically a dedicated shared mailbox such as `realmjoin-report@contoso.com`) is required as the `From` address. The Automation Account's managed identity must be allowed to send on behalf of that mailbox via the Graph `Mail.Send` application permission (scoped via RBAC for Applications if you want to restrict the identity to a single mailbox).
 
+> **The sender must not be a Microsoft 365 group.** The function sends via the Graph endpoint `/users/{EmailFrom}/sendMail` — a Microsoft 365 group is not a user object, so the call fails. Use a user or shared mailbox.
+>
+> Microsoft 365 group addresses as **recipients** are technically accepted, but **not recommended**: the message may only reach the group mailbox (members get a personal copy only if they follow the group), the group's delivery management may reject the sender, and delivery failures surface only as an NDR in the sender mailbox — the runbook itself still reports success. Prefer individual mailbox addresses.
+
 ### Graph permissions
 
 | Scenario | Required permission |
@@ -69,8 +73,8 @@ This produces a fully branded RealmJoin email with the default header and footer
 
 | Parameter | Type | Description |
 |---|---|---|
-| `EmailFrom` | `string` | User principal name or object id of the sender mailbox. Used as `/users/{id}/sendMail`. |
-| `EmailTo` | `string` | Recipient address. **Single string** — multiple addresses are passed as a comma-separated list, see below. |
+| `EmailFrom` | `string` | User principal name or object id of the sender mailbox. Used as `/users/{id}/sendMail`. Must be a user or shared mailbox — a Microsoft 365 group is not a user object and the send fails. |
+| `EmailTo` | `string` | Recipient address. **Single string** — multiple addresses are passed as a comma-separated list, see below. Microsoft 365 group addresses are accepted but not recommended — delivery to members is not guaranteed and failures are not visible to the runbook. |
 | `Subject` | `string` | Subject line. Also injected into the HTML `<title>` element. |
 | `MarkdownContent` | `string` | Report body in Markdown. See [Markdown Support](#markdown-support) for the supported syntax. |
 


### PR DESCRIPTION
## Summary

Documents the Microsoft 365 group limitations for `Send-RjRbReportEmail` — validated against the RealmJoin.RunbookHelper module source and the Microsoft Graph `user: sendMail` documentation:

- **Sender (`EmailFrom`)**: hard limit — the function sends via `POST /users/{EmailFrom}/sendMail`, and a Microsoft 365 group is not a user object, so the call fails. A user or shared mailbox is required.
- **Recipients (`EmailTo`)**: technically accepted, but **not recommended** — the message may only reach the group mailbox (members get a personal copy only if they follow the group), the group's delivery management may reject the sender, and delivery failures surface only as an NDR in the sender mailbox while the runbook still reports success.

## Changes

- `docs/dev-reference/report-functions/send-rjrbreportemail.md`: note in the *Sender mailbox* prerequisites plus clarifications in the `EmailFrom`/`EmailTo` parameter table rows.
- `docs/automation/runbooks/runbook-report-settings.md`: same guidance in short form under the email delivery prerequisites.